### PR TITLE
PR-B3: タイムアウトユーティリティ共通化

### DIFF
--- a/Memora/Core/Services/STTService.swift
+++ b/Memora/Core/Services/STTService.swift
@@ -482,15 +482,11 @@ private final class STTBackendExecutor {
         progress: @escaping @Sendable (Double) -> Void,
         partialResult: @escaping @Sendable (String) -> Void
     ) async throws -> TranscriptionResult {
-        // continuation + DispatchWorkItem でタイムアウトを実装。
-        // withThrowingTaskGroup は全子タスク完了を待つため、
-        // detectSpeakers が非協力的だとタイムアウトが効かない。
-        try await withCheckedThrowingContinuation {
-            (continuation: CheckedContinuation<TranscriptionResult, Error>) in
-            let callbackLock = NSLock()
-            var didResume = false
-
-            let transcriptionTask = Task {
+        // PR-B3: withDeadline 共通ユーティリティでタイムアウトを実装。
+        // SpeechAnalyzer は cooperative cancellation に応答するため
+        // withDeadline の Task.cancel で停止可能。
+        do {
+            return try await withDeadline(seconds: 60) {
                 try await self.transcribeWithSpeechAnalyzer(
                     audioURL: audioURL,
                     locale: locale,
@@ -498,46 +494,9 @@ private final class STTBackendExecutor {
                     partialResult: partialResult
                 )
             }
-
-            // 60秒タイムアウト
-            let timeoutWorkItem = DispatchWorkItem(qos: .userInitiated) {
-                callbackLock.lock()
-                let shouldResume = !didResume
-                didResume = true
-                callbackLock.unlock()
-                if shouldResume {
-                    transcriptionTask.cancel()
-                    DebugLogger.shared.addLog("STTBackend", "SpeechAnalyzer 60秒タイムアウト", level: .warning)
-                    continuation.resume(throwing: OnDeviceTranscriptionTimeoutError())
-                }
-            }
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(
-                deadline: .now() + 60,
-                execute: timeoutWorkItem
-            )
-
-            Task {
-                do {
-                    let result = try await transcriptionTask.value
-                    timeoutWorkItem.cancel()
-                    callbackLock.lock()
-                    let shouldResume = !didResume
-                    didResume = true
-                    callbackLock.unlock()
-                    if shouldResume {
-                        continuation.resume(returning: result)
-                    }
-                } catch {
-                    timeoutWorkItem.cancel()
-                    callbackLock.lock()
-                    let shouldResume = !didResume
-                    didResume = true
-                    callbackLock.unlock()
-                    if shouldResume {
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
+        } catch is DeadlineExceededError {
+            DebugLogger.shared.addLog("STTBackend", "SpeechAnalyzer 60秒タイムアウト", level: .warning)
+            throw OnDeviceTranscriptionTimeoutError()
         }
     }
 
@@ -1169,58 +1128,18 @@ final class STTService: STTServiceProtocol, @unchecked Sendable {
         timeout: TimeInterval = 300
     ) async -> [TranscriptionSegment] {
         DebugLogger.shared.addLog("STTService", "全体ファイル話者分離開始 — \(segments.count)セグメント, numSpeakers: \(numSpeakers?.description ?? "auto"), timeout: \(timeout)s", level: .info)
-        let result = await withTimeout(seconds: timeout) {
-            await self.diarizationService.detectSpeakers(audioURL: audioURL, segments: segments, numSpeakers: numSpeakers)
-        }
-        switch result {
-        case .success(let speakers):
+        do {
+            let speakers = try await withDeadline(seconds: timeout) {
+                await self.diarizationService.detectSpeakers(audioURL: audioURL, segments: segments, numSpeakers: numSpeakers)
+            }
             DebugLogger.shared.addLog("STTService", "全体ファイル話者分離完了 — \(speakers.count)セグメント", level: .info)
             return speakers
-        case .timedOut:
+        } catch {
             DebugLogger.shared.addLog("STTService", "全体ファイル話者分離タイムアウト (\(timeout)s)", level: .warning)
             return segments
         }
     }
 
-    private func withTimeout<T>(
-        seconds: TimeInterval,
-        operation: @escaping () async -> T
-    ) async -> TimeoutResult<T> {
-        await withCheckedContinuation { continuation in
-            let lock = NSLock()
-            var completed = false
-
-            let task = Task {
-                let result = await operation()
-                lock.lock()
-                guard !completed else {
-                    lock.unlock()
-                    return
-                }
-                completed = true
-                lock.unlock()
-                continuation.resume(returning: .success(result))
-            }
-
-            _ = Task {
-                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                lock.lock()
-                guard !completed else {
-                    lock.unlock()
-                    return
-                }
-                completed = true
-                lock.unlock()
-                task.cancel()
-                continuation.resume(returning: .timedOut)
-            }
-        }
-    }
-
-    private enum TimeoutResult<T> {
-        case success(T)
-        case timedOut
-    }
 }
 
 private extension Array {

--- a/Memora/Core/Services/STTSupportTypes.swift
+++ b/Memora/Core/Services/STTSupportTypes.swift
@@ -531,3 +531,59 @@ final class STTDiagnosticsLog: @unchecked Sendable {
         return try? JSONDecoder().decode(STTBackendDiagnosticEntry.self, from: data)
     }
 }
+
+// MARK: - Deadline Utility (PR-B3)
+
+struct DeadlineExceededError: Error, LocalizedError {
+    let seconds: TimeInterval
+    var errorDescription: String? { "処理が \(Int(seconds)) 秒以内に完了しませんでした" }
+}
+
+/// 非協力的な async 作業に期限を課す。
+/// - resume は厳密に1回（期限後に届いた結果/エラーは破棄）。
+/// - 期限発火時: operation Task に cancel を送り、onDeadline を実行してから throw する。
+func withDeadline<T: Sendable>(
+    seconds: TimeInterval,
+    onDeadline: (@Sendable () -> Void)? = nil,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+        let lock = NSLock()
+        var resumed = false
+
+        @Sendable func resumeOnce(_ body: () -> Void) {
+            lock.lock()
+            let shouldRun = !resumed
+            resumed = true
+            lock.unlock()
+            if shouldRun { body() }
+        }
+
+        let work = Task {
+            do {
+                let value = try await operation()
+                resumeOnce { continuation.resume(returning: value) }
+            } catch {
+                resumeOnce { continuation.resume(throwing: error) }
+            }
+        }
+
+        let deadlineItem = DispatchWorkItem(qos: .userInitiated) {
+            resumeOnce {
+                work.cancel()
+                onDeadline?()
+                continuation.resume(throwing: DeadlineExceededError(seconds: seconds))
+            }
+        }
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + seconds,
+            execute: deadlineItem
+        )
+
+        // 正常完了時にタイマーを掃除する監視タスク
+        Task {
+            _ = await work.result
+            deadlineItem.cancel()
+        }
+    }
+}


### PR DESCRIPTION
## 変更概要
継続+DispatchWorkItem+NSLockの同型実装が3箇所に手書き重複していたタイムアウト処理を、`withDeadline()` 汎用ユーティリティに集約。

- `STTSupportTypes.swift` に `withDeadline()` 関数と `DeadlineExceededError` を追加
- SpeechAnalyzer の 60 秒タイムアウトを `withDeadline` に置換
- 話者分離のタイムアウトを `withDeadline` に置換、`withTimeout` / `TimeoutResult` を削除
- SFSpeechRecognizer は delegate コールバック構造が異なるため置換しない

## 変更ファイル
- `Memora/Core/Services/STTSupportTypes.swift` (+47行)
- `Memora/Core/Services/STTService.swift` (+22/-94)

## 影響範囲
- Lane B (STT コア): SpeechAnalyzer バックエンド、話者分離のタイムアウト処理
- SFSpeechRecognizer / API 経路: 影響なし
- 話者分離 / 保存フォーマット: 影響なし（タイムアウト時も既存と同じく元セグメントを返す）
- バックエンド選択順: 変更なし

## 実行した確認
- 設計書 `02_stt_stability.md` §4 との一致を確認
- コード検証: `withTimeout` / `TimeoutResult` がコードベースから消えていることを確認
- SpeechAnalyzer と diarization のログ文言（「60秒タイムアウト」「話者分離タイムアウト」）が同等に出ることを確認
- ビルド: STT 関連のコンパイルエラーなし

## 未確認事項
- 実機でのタイムアウト誘発テスト（テスト整備は PR-E1 で対応）

## 次の PR
PR-E1: STT テスト整備（deadline/marge/silence の単体テスト）

---
Design: `docs/memora-master-package/02_stt_stability.md` §4
