### PR TITLE
PR-E1: STT テスト整備 — withDeadline 単体テスト

### DIFF
--- a/Memora/Core/Services/STTSupportTypes.swift
+++ b/Memora/Core/Services/STTSupportTypes.swift
@@ -531,3 +531,58 @@ final class STTDiagnosticsLog: @unchecked Sendable {
         return try? JSONDecoder().decode(STTBackendDiagnosticEntry.self, from: data)
     }
 }
+
+// MARK: - Deadline Utility (PR-B3)
+
+struct DeadlineExceededError: Error, LocalizedError {
+    let seconds: TimeInterval
+    var errorDescription: String? { "処理が \(Int(seconds)) 秒以内に完了しませんでした" }
+}
+
+/// 非協力的な async 作業に期限を課す。
+/// - resume は厳密に1回（期限後に届いた結果/エラーは破棄）。
+/// - 期限発火時: operation Task に cancel を送り、onDeadline を実行してから throw する。
+func withDeadline<T: Sendable>(
+    seconds: TimeInterval,
+    onDeadline: (@Sendable () -> Void)? = nil,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+        let lock = NSLock()
+        var resumed = false
+
+        @Sendable func resumeOnce(_ body: () -> Void) {
+            lock.lock()
+            let shouldRun = !resumed
+            resumed = true
+            lock.unlock()
+            if shouldRun { body() }
+        }
+
+        let work = Task {
+            do {
+                let value = try await operation()
+                resumeOnce { continuation.resume(returning: value) }
+            } catch {
+                resumeOnce { continuation.resume(throwing: error) }
+            }
+        }
+
+        let deadlineItem = DispatchWorkItem(qos: .userInitiated) {
+            resumeOnce {
+                work.cancel()
+                onDeadline?()
+                continuation.resume(throwing: DeadlineExceededError(seconds: seconds))
+            }
+        }
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(
+            deadline: .now() + seconds,
+            execute: deadlineItem
+        )
+
+        Task {
+            _ = await work.result
+            deadlineItem.cancel()
+        }
+    }
+}

--- a/MemoraTests/Services/STTDeadlineTests.swift
+++ b/MemoraTests/Services/STTDeadlineTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+@testable import Memora
+
+// MARK: - STT Deadline Tests (PR-E1)
+
+/// NSLock ラッパー（テスト用のスレッドセーフな状態保持）
+private final class LockedBox<T> {
+    private let lock = NSLock()
+    private var value: T
+    init(_ value: T) { self.value = value }
+    func get() -> T { lock.lock(); defer { lock.unlock() }; return value }
+    func set(_ value: T) { lock.lock(); defer { lock.unlock() }; self.value = value }
+    func mutate(_ body: (inout T) -> Void) {
+        lock.lock()
+        body(&value)
+        lock.unlock()
+    }
+}
+
+struct STTDeadlineTests {
+
+    @Test("即時成功は値を返す")
+    func immediateSuccess() async throws {
+        let value = try await withDeadline(seconds: 5) { 42 }
+        #expect(value == 42)
+    }
+
+    @Test("期限超過は DeadlineExceededError を投げる")
+    func deadlineExceeded() async {
+        do {
+            _ = try await withDeadline(seconds: 0.1) {
+                try? await Task.sleep(for: .milliseconds(400))
+                return 1
+            }
+            Issue.record("should throw")
+        } catch {
+            #expect(error is DeadlineExceededError)
+        }
+        // 遅延完了が resume を試みる時間まで待つ（double-resume なら fatal）
+        try? await Task.sleep(for: .milliseconds(600))
+    }
+
+    @Test("期限超過後もクラッシュしない（遅延完了の破棄）")
+    func lateCompletionDiscarded() async {
+        let completed = LockedBox(false)
+        _ = try? await withDeadline(seconds: 0.1) {
+            try? await Task.sleep(for: .milliseconds(400))
+            completed.set(true)
+            return 1
+        }
+        try? await Task.sleep(for: .milliseconds(500))
+        // クラッシュせずここまで到達すれば OK
+        #expect(Bool(true))
+    }
+
+    @Test("onDeadline フックがタイムアウト時に1回だけ呼ばれる")
+    func onDeadlineHookInvokedOnce() async {
+        let count = LockedBox(0)
+        _ = try? await withDeadline(
+            seconds: 0.1,
+            onDeadline: { count.mutate { $0 += 1 } }
+        ) {
+            try? await Task.sleep(for: .seconds(1))
+            return 0
+        }
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(count.get() == 1)
+    }
+
+    @Test("onDeadline フックは通常完了時には呼ばれない")
+    func onDeadlineNotCalledOnSuccess() async throws {
+        let count = LockedBox(0)
+        let value = try await withDeadline(
+            seconds: 5,
+            onDeadline: { count.mutate { $0 += 1 } }
+        ) { 99 }
+        #expect(value == 99)
+        #expect(count.get() == 0)
+    }
+}

--- a/MemoraTests/Services/STTTestDoubles.swift
+++ b/MemoraTests/Services/STTTestDoubles.swift
@@ -1,0 +1,59 @@
+import Foundation
+@testable import Memora
+
+// MARK: - STT Test Doubles (PR-E1)
+
+final class FakeReadiness: STTReadinessProtocol {
+    var isReady: Bool { get async { true } }
+    var supportedLanguages: [String] { get async { ["ja", "en"] } }
+    var requiresDownload: Bool { get async { false } }
+    func prepare() async throws {}
+}
+
+final class FakeChunker: AudioChunkerProtocol {
+    let chunks: [AudioChunk]
+    private(set) var cleanupCalled = false
+    private(set) var cleanupChunkCalls: [Int] = []
+
+    init(chunks: [AudioChunk]) {
+        self.chunks = chunks
+    }
+
+    func analyzeAndChunk(
+        fileURL: URL,
+        onProgress: AudioChunkProgressHandler?
+    ) async throws -> [AudioChunk] {
+        onProgress?(chunks.count, chunks.count)
+        return chunks
+    }
+
+    func plan(fileURL: URL) async throws -> AudioChunkPlan {
+        let slices: [AudioChunkPlan.Slice] = chunks.map {
+            AudioChunkPlan.Slice(index: $0.index, startSec: $0.startSec, endSec: $0.endSec)
+        }
+        let totalDuration = chunks.last?.endSec ?? 0
+        return AudioChunkPlan(
+            sourceURL: fileURL,
+            totalDuration: totalDuration,
+            slices: slices
+        )
+    }
+
+    func exportSlice(
+        _ slice: AudioChunkPlan.Slice,
+        from plan: AudioChunkPlan
+    ) async throws -> AudioChunk {
+        guard let chunk = chunks.first(where: { $0.index == slice.index }) else {
+            throw NSError(domain: "FakeChunker", code: -1)
+        }
+        return chunk
+    }
+
+    func cleanup(chunks: [AudioChunk]) async {
+        cleanupCalled = true
+    }
+
+    func cleanupChunk(_ chunk: AudioChunk) async {
+        cleanupChunkCalls.append(chunk.index)
+    }
+}

--- a/MemoraTests/Services/TestAudioFactory.swift
+++ b/MemoraTests/Services/TestAudioFactory.swift
@@ -1,0 +1,81 @@
+import Foundation
+import AVFoundation
+
+// MARK: - Test Audio Factory (PR-E1)
+
+enum TestAudioFactory {
+    /// 指定秒数の 440Hz 正弦波 WAV を一時ディレクトリに生成
+    static func makeSineWAV(
+        seconds: Double,
+        sampleRate: Double = 16_000
+    ) throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_sine_\(UUID().uuidString).wav")
+        let format = AVAudioFormat(
+            standardFormatWithSampleRate: sampleRate,
+            channels: 1
+        )!
+        let frameCount = AVAudioFrameCount(seconds * sampleRate)
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: frameCount
+        ) else {
+            throw NSError(domain: "TestAudioFactory", code: -1)
+        }
+        buffer.frameLength = frameCount
+        let frequency: Float = 440
+        if let channel = buffer.floatChannelData?[0] {
+            for i in 0..<Int(frameCount) {
+                let t = Float(i) / Float(sampleRate)
+                channel[i] = sin(2 * .pi * frequency * t) * 0.3
+            }
+        }
+        let file = try AVAudioFile(
+            forWriting: tmp,
+            settings: format.settings
+        )
+        try file.write(from: buffer)
+        return tmp
+    }
+
+    /// 前半 tone（正弦波）+ 後半無音の WAV
+    static func makeToneThenSilenceWAV(
+        toneSeconds: Double,
+        silenceSeconds: Double,
+        sampleRate: Double = 16_000
+    ) throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test_tone_silence_\(UUID().uuidString).wav")
+        let totalSeconds = toneSeconds + silenceSeconds
+        let format = AVAudioFormat(
+            standardFormatWithSampleRate: sampleRate,
+            channels: 1
+        )!
+        let frameCount = AVAudioFrameCount(totalSeconds * sampleRate)
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: frameCount
+        ) else {
+            throw NSError(domain: "TestAudioFactory", code: -1)
+        }
+        buffer.frameLength = frameCount
+        let frequency: Float = 440
+        let toneFrames = Int(toneSeconds * sampleRate)
+        if let channel = buffer.floatChannelData?[0] {
+            for i in 0..<Int(frameCount) {
+                if i < toneFrames {
+                    let t = Float(i) / Float(sampleRate)
+                    channel[i] = sin(2 * .pi * frequency * t) * 0.3
+                } else {
+                    channel[i] = 0
+                }
+            }
+        }
+        let file = try AVAudioFile(
+            forWriting: tmp,
+            settings: format.settings
+        )
+        try file.write(from: buffer)
+        return tmp
+    }
+}


### PR DESCRIPTION
## 変更概要
STT テスト基盤と `withDeadline` の単体テストを追加。

- `withDeadline()` 汎用タイムアウト関数を `STTSupportTypes.swift` に追加
- `STTTestDoubles.swift`: `FakeReadiness` / `FakeChunker` を追加
- `TestAudioFactory.swift`: 正弦波 WAV 生成ユーティリティ
- `STTDeadlineTests.swift`: 5 テストケース
  - 即時成功
  - 期限超過で `DeadlineExceededError`
  - 期限後遅延完了の破棄（double-resume なし）
  - `onDeadline` フックがタイムアウト時に1回だけ発火
  - `onDeadline` フックが正常完了時は発火しない

## 変更ファイル
- `Memora/Core/Services/STTSupportTypes.swift` (+48行: `withDeadline`)
- `MemoraTests/Services/STTTestDoubles.swift` (新規)
- `MemoraTests/Services/TestAudioFactory.swift` (新規)
- `MemoraTests/Services/STTDeadlineTests.swift` (新規)

## 影響範囲
- Lane E (QA): テストファイルのみ、プロダクションコードは `withDeadline` 追加のみ

## 実行した確認
- ビルド: `withDeadline` / test doubles / test factory のコンパイルエラーなし
- テスト実行: アプリターゲットの既存 `ToDoView.swift` エラーによりテストターゲット全体がビルド不可（`origin/main` 同様の既存問題）
- テストコード構造: Swift Testing の既存流儀（`@Test`, `#expect`）に準拠

## 未確認事項
- `ToDoView.swift` 修正後のテスト green 確認（コードは設計書通りのため PASS 想定）

## 次の PR
PR-B4: 末尾無音カバレッジ誤検知の抑制

---
Design: `docs/memora-master-package/08_test_plan.md` §1-2
