### PR TITLE
fix: resolve fingerprint escape bug in makeFingerprint (P-2)

### DIFF
--- a/Memora/Core/Services/STTService.swift
+++ b/Memora/Core/Services/STTService.swift
@@ -708,6 +708,14 @@ final class STTService: STTServiceProtocol, @unchecked Sendable {
 
     var checkpointHooks: STTCheckpointHooks?
 
+    private func audioFileDuration(for url: URL) async -> TimeInterval {
+        let asset = AVURLAsset(url: url)
+        guard let duration = try? await asset.load(.duration) else {
+            return 0
+        }
+        return CMTimeGetSeconds(duration)
+    }
+
     private let readiness: STTReadinessProtocol
     private let chunkerFactory: @Sendable () -> AudioChunkerProtocol
     private let diarizationService: SpeakerDiarizationProtocol = {
@@ -815,10 +823,10 @@ final class STTService: STTServiceProtocol, @unchecked Sendable {
     }
 
 
-    private func makeFingerprint(url: URL, chunkCount: Int) async -> String {
+    func makeFingerprint(url: URL, chunkCount: Int) async -> String {
         let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int64) ?? -1
         let duration = Int(await audioFileDuration(for: url))
-        return "\\(size)-\\(duration)-\\(chunkCount)"
+        return "\(size)-\(duration)-\(chunkCount)"
     }
 
     private func runTask(
@@ -858,7 +866,7 @@ final class STTService: STTServiceProtocol, @unchecked Sendable {
                 let saved = await hooks.load(fingerprint) 
                 restoredResults = saved.mapValues { $0.toTranscriptionResult() } 
                 if !restoredResults.isEmpty { 
-                    DebugLogger.shared.addLog("STTService", "チェックポイント復元 — \\(restoredResults.count)/\\(preparedChunks.count) チャンクを再利用", level: .info) 
+                    DebugLogger.shared.addLog("STTService", "チェックポイント復元 — \(restoredResults.count)/\(preparedChunks.count) チャンクを再利用", level: .info) 
                 } 
             }
             let totalChunks = max(preparedChunks.count, 1)

--- a/MemoraTests/Services/STTServiceTests.swift
+++ b/MemoraTests/Services/STTServiceTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import Foundation
+@testable import Memora
+
+// MARK: - STTService makeFingerprint Tests
+
+struct STTServiceFingerprintTests {
+
+    @Test("異なるファイルサイズで異なるfingerprintが生成される")
+    func differentSizesProduceDifferentFingerprints() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+
+        let url1 = tmpDir.appendingPathComponent("test_audio_1.m4a")
+        let url2 = tmpDir.appendingPathComponent("test_audio_2.m4a")
+
+        // Create files with different sizes
+        let data1 = Data(repeating: 0x00, count: 1024)
+        let data2 = Data(repeating: 0x00, count: 4096)
+        try data1.write(to: url1)
+        try data2.write(to: url2)
+        defer {
+            try? FileManager.default.removeItem(at: url1)
+            try? FileManager.default.removeItem(at: url2)
+        }
+
+        let sttService = STTService()
+        let fp1 = await sttService.makeFingerprint(url: url1, chunkCount: 5)
+        let fp2 = await sttService.makeFingerprint(url: url2, chunkCount: 5)
+
+        #expect(fp1 != fp2, "異なるファイルサイズで異なるfingerprintになること")
+    }
+
+    @Test("異なるchunkCountで異なるfingerprintが生成される")
+    func differentChunkCountsProduceDifferentFingerprints() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+        let url = tmpDir.appendingPathComponent("test_audio_chunk.m4a")
+        let data = Data(repeating: 0x00, count: 2048)
+        try data.write(to: url)
+        defer {
+            try? FileManager.default.removeItem(at: url)
+        }
+
+        let sttService = STTService()
+        let fp1 = await sttService.makeFingerprint(url: url, chunkCount: 3)
+        let fp2 = await sttService.makeFingerprint(url: url, chunkCount: 7)
+
+        #expect(fp1 != fp2, "異なるchunkCountで異なるfingerprintになること")
+    }
+
+    @Test("fingerprintに文字列補間のリテラル表記が含まれない（エスケープバグがない）")
+    func fingerprintDoesNotContainLiteralInterpolationSyntax() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+        let url = tmpDir.appendingPathComponent("test_audio_format.m4a")
+        let data = Data(repeating: 0xFF, count: 512)
+        try data.write(to: url)
+        defer {
+            try? FileManager.default.removeItem(at: url)
+        }
+
+        let sttService = STTService()
+        let fp = await sttService.makeFingerprint(url: url, chunkCount: 10)
+
+        // バグがあると "\\(size)-\\(duration)-\\(chunkCount)" というリテラル文字列になる
+        #expect(!fp.contains("\\("), "fingerprintにエスケープされた文字列補間リテラルが含まれていないこと")
+        #expect(!fp.contains("size"), "fingerprintに変数名 'size' が含まれていないこと")
+        #expect(!fp.contains("duration"), "fingerprintに変数名 'duration' が含まれていないこと")
+        #expect(!fp.contains("chunkCount"), "fingerprintに変数名 'chunkCount' が含まれていないこと")
+    }
+
+    @Test("fingerprintが数値とハイフンで構成される")
+    func fingerprintConsistsOfNumbersAndHyphens() async throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+        let url = tmpDir.appendingPathComponent("test_audio_numeric.m4a")
+        let data = Data(repeating: 0xAA, count: 256)
+        try data.write(to: url)
+        defer {
+            try? FileManager.default.removeItem(at: url)
+        }
+
+        let sttService = STTService()
+        let fp = await sttService.makeFingerprint(url: url, chunkCount: 1)
+
+        // フォーマット: "size-duration-chunkCount" (例: "256-0-1")
+        let parts = fp.split(separator: "-")
+        #expect(parts.count == 3, "fingerprintは3つの数値をハイフンで結合した形式であること")
+
+        for part in parts {
+            #expect(Int(part) != nil, "各部分 '\(part)' が整数であること")
+        }
+    }
+}


### PR DESCRIPTION
## 概要
設計書 32_ph2_merge_plan.md §3（P-2）の指摘に基づき、`makeFingerprint` のエスケープバグを修正。

## バグ内容
```swift
// 修正前: \\( がエスケープされ、文字列補間が無効化
return "\\(size)-\\(duration)-\\(chunkCount)"  // → 常に "\(size)-\(duration)-\(chunkCount)" を返す

// 修正後: 正しい文字列補間
return "\(size)-\(duration)-\(chunkCount)"      // → "1024-60-5" のように実際の値
```

## 変更
- `STTService.swift`: makeFingerprint と DebugLogger の \\( → \( (計2箇所)
- `STTService.swift`: audioFileDuration を STTService に追加（元コードは STTBackendExecutor にあり makeFingerprint から呼べなかった）
- `STTService.swift`: makeFingerprint のアクセスレベルを private → internal（テスト可能に）
- `STTServiceTests.swift`: 新規テスト追加（異なる入力で異なる fingerprint / リテラル非混入 / 数値フォーマット）

## 検証
- スタンドアロン Swift スクリプトで全テストケース通過確認
- ブランチ自体は事前ビルドエラーあり（Phase B リベース時に解消予定）