### PR TITLE
feat: 外部レコーダー取り込みを改善

### DIFF
--- a/Memora.xcodeproj/project.pbxproj
+++ b/Memora.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		DF3C4EF825F95EA41E303DBF /* DeviceConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90319B078F7AF12E0E2D146F /* DeviceConnectionView.swift */; };
 		E2A0EADE30B71989C0E7A8A7 /* PlaudSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88239E9736BD88127DA7CF2 /* PlaudSettings.swift */; };
 		E410D4D2DB0A17C46B31A024 /* PlaudImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E18D3E00732A71CB8A413E6 /* PlaudImportService.swift */; };
+		ECA899D64CF848F697283F35 /* ImportRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B18191F73324864A0281C5F /* ImportRouter.swift */; };
+		2AE00304F821447280A3E602 /* ImportRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665161B7F35842A392312262 /* ImportRouterTests.swift */; };
 		E58B0992DD53733CBB12F7DE /* FileDetailHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F366D454C3871B21F0C2D19 /* FileDetailHelpers.swift */; };
 		E73CCF1294886F5DF097CFC5 /* SkeletonProjectCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A198FF7BB4D7F734439746 /* SkeletonProjectCard.swift */; };
 		E93121C82A1D17B692B1CE0C /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D1A0CE151A9D7FA10850B3 /* AudioRecorder.swift */; };
@@ -381,6 +383,8 @@
 		9C11AD42B19158882B877B1D /* CalendarEventLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventLink.swift; sourceTree = "<group>"; };
 		9C4553313913B67C7BDC4CDF /* STTSupportTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STTSupportTypes.swift; sourceTree = "<group>"; };
 		9E18D3E00732A71CB8A413E6 /* PlaudImportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaudImportService.swift; sourceTree = "<group>"; };
+		0B18191F73324864A0281C5F /* ImportRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportRouter.swift; sourceTree = "<group>"; };
+		665161B7F35842A392312262 /* ImportRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportRouterTests.swift; sourceTree = "<group>"; };
 		9E2676B0A3FF3CCCB12C4736 /* MeetingCaptureViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCaptureViewModel.swift; sourceTree = "<group>"; };
 		9F18FDF85B122CB5DB69E438 /* DeveloperFeaturesSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeveloperFeaturesSection.swift; sourceTree = "<group>"; };
 		A0D2DD160DF4AF641FD9CD52 /* FloatingGlassTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingGlassTabBar.swift; sourceTree = "<group>"; };
@@ -684,6 +688,7 @@
 		345340EB32FFC99C3344F792 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				AFF17E800EDF49928DD044FE /* Capture */,
 				CE3B825F616D090FBEB31CB1 /* Contracts */,
 				AAA29B6187B411700E874C1A /* Models */,
 				38C374DDEF23A65411819DCF /* Networking */,
@@ -692,6 +697,14 @@
 				326F8DFE600109A52BEC818C /* ViewModels */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		AFF17E800EDF49928DD044FE /* Capture */ = {
+			isa = PBXGroup;
+			children = (
+				0B18191F73324864A0281C5F /* ImportRouter.swift */,
+			);
+			path = Capture;
 			sourceTree = "<group>";
 		};
 		38C374DDEF23A65411819DCF /* Networking */ = {
@@ -768,6 +781,7 @@
 				578CADDA2E5E15C0BDC288E0 /* FileDetailViewModelTests.swift */,
 				3114A00A5EF9D97405BFC124 /* HomeViewModelTests.swift */,
 				A7C606CEF85C1406BC777BC4 /* ProjectsViewModelTests.swift */,
+				665161B7F35842A392312262 /* ImportRouterTests.swift */,
 				9A456B5536BB720E54CD2148 /* TestHelpers.swift */,
 				3198A76799E51BC9678E0DEE /* Models */,
 				8C961D33C3564C2473C2DA5E /* Repositories */,
@@ -1105,6 +1119,7 @@
 				CE33BBC7E9FDD342715A4099 /* TodoItemRepositoryTests.swift in Sources */,
 				37B189A82F502FD789C37D22 /* TodoItemTests.swift in Sources */,
 				3C911511079A36C412B15845 /* TranscriptTests.swift in Sources */,
+				2AE00304F821447280A3E602 /* ImportRouterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1249,6 +1264,7 @@
 				DC40C87BAF5C918F56E3E4B5 /* PipelineCoordinator.swift in Sources */,
 				064758E3B9EAA481C111A22B /* PlaudExportModels.swift in Sources */,
 				E410D4D2DB0A17C46B31A024 /* PlaudImportService.swift in Sources */,
+				ECA899D64CF848F697283F35 /* ImportRouter.swift in Sources */,
 				CFBC49F5F5C245131F32412B /* PlaudRecording.swift in Sources */,
 				30135C876AB2ED21B1599CA1 /* PlaudService.swift in Sources */,
 				E2A0EADE30B71989C0E7A8A7 /* PlaudSettings.swift in Sources */,

--- a/Memora/Core/Capture/ImportRouter.swift
+++ b/Memora/Core/Capture/ImportRouter.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// ファイル選択結果を、音声と付随テキストの組み合わせごとに分類する。
+/// ファイルI/Oを行わないため、UIから独立してテストできる。
+enum ImportRouter {
+    enum Route {
+        case plaudExport(audio: URL, json: URL)
+        case plaudTranscript(audio: URL, text: URL)
+        case audioOnly(URL)
+        case textOnly(URL)
+    }
+
+    private static let audioExtensions: Set<String> = [
+        "m4a", "wav", "mp3", "aac", "caf", "aiff"
+    ]
+
+    static func route(_ urls: [URL]) -> [Route] {
+        let groups = Dictionary(grouping: urls) { url in
+            url.deletingPathExtension().lastPathComponent
+        }
+
+        return groups.keys.sorted().flatMap { basename in
+            let group = (groups[basename] ?? []).sorted { $0.path < $1.path }
+            var jsonFiles = group.filter { $0.pathExtension.lowercased() == "json" }
+            var textFiles = group.filter { $0.pathExtension.lowercased() == "txt" }
+            let audioFiles = group.filter { audioExtensions.contains($0.pathExtension.lowercased()) }
+            var routes: [Route] = []
+
+            for audio in audioFiles {
+                if let json = jsonFiles.first {
+                    jsonFiles.removeFirst()
+                    routes.append(.plaudExport(audio: audio, json: json))
+                } else if let text = textFiles.first {
+                    textFiles.removeFirst()
+                    routes.append(.plaudTranscript(audio: audio, text: text))
+                } else {
+                    routes.append(.audioOnly(audio))
+                }
+            }
+
+            // 同名ファイルが複数あっても、未使用のテキストを捨てない。
+            routes += jsonFiles.map(Route.textOnly)
+            routes += textFiles.map(Route.textOnly)
+            return routes
+        }
+    }
+}

--- a/Memora/Core/Services/AudioFileImportService.swift
+++ b/Memora/Core/Services/AudioFileImportService.swift
@@ -47,6 +47,9 @@ enum AudioFileImportService {
 
         let audioFile = AudioFile(title: resolvedTitle, audioURL: destinationURL.path)
         audioFile.duration = durationSeconds.isFinite ? durationSeconds : 0
+        if let creationDate = try? sourceURL.resourceValues(forKeys: [.creationDateKey]).creationDate {
+            audioFile.createdAt = creationDate
+        }
 
         modelContext.insert(audioFile)
         try modelContext.save()

--- a/Memora/Views/HomeView.swift
+++ b/Memora/Views/HomeView.swift
@@ -27,6 +27,7 @@ struct HomeView: View {
     @State private var showFileImporter = false
     @State private var showGoogleMeetImport = false
     @State private var importErrorMessage: String?
+    @State private var importStatusMessage: String?
 
     // 検索・フィルタリング用
     @State private var searchText = ""
@@ -56,7 +57,7 @@ struct HomeView: View {
     private typealias SortOption = HomeViewModel.SortOption
 
     private var importContentTypes: [UTType] {
-        [.mpeg4Audio, .wav, .mp3, .aiff, .json, .plainText].compactMap { $0 }
+        [.mpeg4Audio, .wav, .mp3, .aiff, .audio, .json, .plainText].compactMap { $0 }
     }
 
     init(pendingOpenedAudioFileID: Binding<UUID?> = .constant(nil), isTabBarHidden: Binding<Bool> = .constant(false), triggerRecording: Binding<Bool> = .constant(false), triggerFileImport: Binding<Bool> = .constant(false)) {
@@ -201,6 +202,18 @@ struct HomeView: View {
                 guard newValue else { return }
                 triggerFileImport = false
                 showFileImporter = true
+            }
+            .overlay(alignment: .bottom) {
+                if let importStatusMessage {
+                    Text(importStatusMessage)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                        .background(.black.opacity(0.82), in: Capsule())
+                        .padding(.bottom, 24)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
             .onChange(of: searchText) { _, _ in
                 searchDebounceTask?.cancel()
@@ -628,85 +641,116 @@ struct HomeView: View {
         switch result {
         case .success(let urls):
             guard !urls.isEmpty else { return }
-            let audioExtensions: Set<String> = ["m4a", "mp3", "wav", "aiff", "aac"]
-            let audioURLs = urls.filter { audioExtensions.contains($0.pathExtension.lowercased()) }
-            let otherURLs = urls.filter { !audioExtensions.contains($0.pathExtension.lowercased()) }
-
-            for url in audioURLs {
-                importAudioFile(from: url)
-            }
-            if !otherURLs.isEmpty {
-                importPlaudFiles(otherURLs)
-            }
+            importRoutes(ImportRouter.route(urls))
         case .failure(let error):
             print("[HomeView] File import failed: \(error.localizedDescription)")
             importErrorMessage = "ファイルの選択に失敗しました。もう一度お試しください。"
         }
     }
 
-    private func importAudioFile(from url: URL) {
-        do {
-            let audioFile = try AudioFileImportService.importAudio(
-                from: url,
-                modelContext: modelContext,
-                requiresSecurityScopedAccess: true
-            )
-            pendingOpenedAudioFileID = audioFile.id
-        } catch {
-            print("[HomeView] Audio file import failed: \(error.localizedDescription)")
-            importErrorMessage = "音声ファイルのインポートに失敗しました。もう一度お試しください。"
-        }
-    }
-
-    private func importPlaudFiles(_ urls: [URL]) {
+    private func importRoutes(_ routes: [ImportRouter.Route]) {
+        var importedCount = 0
+        var failureCount = 0
         var lastImportedID: UUID?
-        for url in urls {
-            let ext = url.pathExtension.lowercased()
-            if ext == "json" {
-                if let file = importPlaudJSON(url: url) { lastImportedID = file.id }
-            } else {
-                if let file = importPlaudText(url: url) { lastImportedID = file.id }
+
+        for route in routes {
+            do {
+                let importedFile: AudioFile
+                switch route {
+                case let .plaudExport(audio, json):
+                    importedFile = try PlaudImportService.importFromExport(
+                        audioURL: audio,
+                        metadataURL: json,
+                        modelContext: modelContext
+                    )
+                case let .plaudTranscript(audio, textURL):
+                    importedFile = try AudioFileImportService.importAudio(
+                        from: audio,
+                        modelContext: modelContext,
+                        requiresSecurityScopedAccess: true
+                    )
+                    importedCount += 1
+                    lastImportedID = importedFile.id
+                    do {
+                        PlaudImportService.attachReferenceTranscript(
+                            importedFile,
+                            text: try readText(from: textURL),
+                            modelContext: modelContext
+                        )
+                    } catch {
+                        failureCount += 1
+                        print("[HomeView] Reference transcript import failed: \(error.localizedDescription)")
+                    }
+                    continue
+                case let .audioOnly(audio):
+                    importedFile = try AudioFileImportService.importAudio(
+                        from: audio,
+                        modelContext: modelContext,
+                        requiresSecurityScopedAccess: true
+                    )
+                case let .textOnly(file):
+                    importedFile = try importTextOnly(file)
+                }
+                importedCount += 1
+                lastImportedID = importedFile.id
+            } catch {
+                failureCount += 1
+                print("[HomeView] File import failed: \(error.localizedDescription)")
             }
         }
-        if let lastImportedID { pendingOpenedAudioFileID = lastImportedID }
+
+        if let lastImportedID {
+            pendingOpenedAudioFileID = lastImportedID
+        }
+        viewModel.loadAudioFiles()
+        updateFilteredFiles()
+        showImportStatus(importedCount: importedCount, failureCount: failureCount)
     }
 
-    private func importPlaudJSON(url: URL) -> AudioFile? {
-        do {
-            let didAccess = url.startAccessingSecurityScopedResource()
-            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-            let data = try Data(contentsOf: url)
-            let export = try JSONDecoder().decode(PlaudExportFile.self, from: data)
-            let title = export.title ?? url.deletingPathExtension().lastPathComponent
-            let text = export.transcript?.isEmpty == false ? export.transcript! : (export.summary ?? "")
-            let file = PlaudImportService.importTextOnly(title: title, textContent: text, modelContext: modelContext)
+    private func importTextOnly(_ url: URL) throws -> AudioFile {
+        let text = try readText(from: url)
+        if url.pathExtension.lowercased() == "json",
+           let export = try? JSONDecoder().decode(PlaudExportFile.self, from: Data(text.utf8)) {
+            let transcript = export.transcript?.isEmpty == false ? export.transcript! : (export.summary ?? "")
+            let file = PlaudImportService.importTextOnly(
+                title: export.title ?? url.deletingPathExtension().lastPathComponent,
+                textContent: transcript,
+                modelContext: modelContext
+            )
             if let summary = export.summary, !summary.isEmpty {
                 file.summary = summary
                 file.isSummarized = true
-                try? modelContext.save()
             }
+            if let createdAt = export.createdAt {
+                file.createdAt = createdAt
+            }
+            try modelContext.save()
             return file
-        } catch {
-            print("[HomeView] Plaud JSON import failed: \(error.localizedDescription)")
-            importErrorMessage = "Plaud ファイルのインポートに失敗しました。もう一度お試しください。"
-            return nil
         }
+
+        return PlaudImportService.importTextOnly(
+            title: url.deletingPathExtension().lastPathComponent,
+            textContent: text,
+            modelContext: modelContext
+        )
     }
 
-    private func importPlaudText(url: URL) -> AudioFile? {
-        do {
-            let didAccess = url.startAccessingSecurityScopedResource()
-            defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
-            let text = try String(contentsOf: url, encoding: .utf8)
-            return PlaudImportService.importTextOnly(
-                title: url.deletingPathExtension().lastPathComponent,
-                textContent: text,
-                modelContext: modelContext
-            )
-        } catch {
-            print("[HomeView] Plaud text import failed: \(error.localizedDescription)")
-            importErrorMessage = "Plaud ファイルのインポートに失敗しました。もう一度お試しください。"
-            return nil
+    private func readText(from url: URL) throws -> String {
+        let didAccess = url.startAccessingSecurityScopedResource()
+        defer { if didAccess { url.stopAccessingSecurityScopedResource() } }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func showImportStatus(importedCount: Int, failureCount: Int) {
+        var message = "\(importedCount)件を取り込みました"
+        if failureCount > 0 {
+            message += "（\(failureCount)件失敗）"
+        }
+        importStatusMessage = message
+        Task {
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            importStatusMessage = nil
         }
     }
 

--- a/Memora/Views/Settings/DeveloperFeaturesSection.swift
+++ b/Memora/Views/Settings/DeveloperFeaturesSection.swift
@@ -5,24 +5,26 @@ import SwiftData
 
 struct DeveloperFeaturesSection: View {
     @Bindable var state: SettingsState
+#if DEBUG
     @Environment(\.modelContext) private var modelContext
     @Query private var plaudSettingsList: [PlaudSettings]
 
     private var plaudSettings: PlaudSettings? {
         plaudSettingsList.first
     }
+#endif
 
     var body: some View {
         Section {
-            // Plaud エクスポートインポート説明
+            // 書き出しファイルの取り込み説明
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Image(systemName: "doc.badge.plus")
                         .foregroundStyle(MemoraColor.accentBlue)
-                    Text("Plaud エクスポートインポート")
+                    Text("書き出しファイルの取り込み")
                         .font(MemoraTypography.subheadline)
                 }
-                Text("FAB の「Plaud」ボタンから Plaud アプリのエクスポートファイル（JSON/TXT）をインポートできます。")
+                Text("PLAUDアプリの書き出しを含む音声・JSON・TXTファイルは、ホームのファイル読み込みから取り込めます。")
                     .font(MemoraTypography.caption1)
                     .foregroundStyle(.secondary)
             }
@@ -97,7 +99,8 @@ struct DeveloperFeaturesSection: View {
             }
             .padding(.vertical, MemoraSpacing.xxxs)
 
-            // Plaud 連携 Toggle
+            // 非公式 API を使う開発用のログイン・同期 UI
+#if DEBUG
             Toggle("Plaud 連携を有効化", isOn: Binding(
                 get: { plaudSettings?.isEnabled ?? false },
                 set: { newValue in
@@ -123,9 +126,11 @@ struct DeveloperFeaturesSection: View {
             if plaudSettings?.isEnabled ?? false {
                 plaudSettingsContent
             }
+#endif
         }
     }
 
+#if DEBUG
     @ViewBuilder
     private var plaudSettingsContent: some View {
         if state.isLoggedIn {
@@ -417,4 +422,5 @@ struct DeveloperFeaturesSection: View {
         formatter.locale = Locale(identifier: "ja_JP")
         return formatter.string(from: date)
     }
+#endif
 }

--- a/Memora/Views/Settings/DeviceConnectionSection.swift
+++ b/Memora/Views/Settings/DeviceConnectionSection.swift
@@ -12,6 +12,14 @@ struct DeviceConnectionSection: View {
 
     var body: some View {
         Section {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Omi は Bluetooth Low Energy（BLE）で直接接続します。")
+                    .font(MemoraTypography.caption1)
+                Text("PLAUDなどのレコーダーは、各アプリやFilesから書き出した音声・JSON・TXTファイルをホームのファイル読み込みで取り込めます。")
+                    .font(MemoraTypography.caption1)
+                    .foregroundStyle(.secondary)
+            }
+
             if !omiAdapter.sdkAvailable {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Omi Swift SDK が未設定です")
@@ -140,7 +148,7 @@ struct DeviceConnectionSection: View {
                 }
             }
         } header: {
-            GlassSectionHeader(title: "Omi 接続", icon: "headphones")
+            GlassSectionHeader(title: "録音デバイス", icon: "headphones")
         }
     }
 }

--- a/MemoraTests/ImportRouterTests.swift
+++ b/MemoraTests/ImportRouterTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import Memora
+
+struct ImportRouterTests {
+    @Test("同名の音声とJSONをPLA​​UDエクスポートとして分類する")
+    func routesAudioAndJSONAsPlaudExport() {
+        let routes = ImportRouter.route([url("meeting.m4a"), url("meeting.json")])
+
+        #expect(routes.count == 1)
+        guard case let .plaudExport(audio, json) = routes.first else {
+            Issue.record("Expected plaudExport route")
+            return
+        }
+        #expect(audio.lastPathComponent == "meeting.m4a")
+        #expect(json.lastPathComponent == "meeting.json")
+    }
+
+    @Test("同名の音声とTXTを参照文字起こしとして分類する")
+    func routesAudioAndTextAsPlaudTranscript() {
+        let routes = ImportRouter.route([url("interview.wav"), url("interview.txt")])
+
+        #expect(routes.count == 1)
+        guard case let .plaudTranscript(audio, text) = routes.first else {
+            Issue.record("Expected plaudTranscript route")
+            return
+        }
+        #expect(audio.lastPathComponent == "interview.wav")
+        #expect(text.lastPathComponent == "interview.txt")
+    }
+
+    @Test("音声のみとテキストのみをそれぞれ保持して分類する")
+    func routesStandaloneFilesWithoutDroppingThem() {
+        let routes = ImportRouter.route([url("recorder.caf"), url("notes.txt"), url("export.json")])
+
+        #expect(routes.count == 3)
+        #expect(routes.contains { if case .audioOnly(let file) = $0 { file.lastPathComponent == "recorder.caf" } else { false } })
+        #expect(routes.contains { if case .textOnly(let file) = $0 { file.lastPathComponent == "notes.txt" } else { false } })
+        #expect(routes.contains { if case .textOnly(let file) = $0 { file.lastPathComponent == "export.json" } else { false } })
+    }
+
+    @Test("JSONを優先し、余った同名TXTはテキストのみとして残す")
+    func preservesUnusedSameBasenameText() {
+        let routes = ImportRouter.route([url("memo.mp3"), url("memo.json"), url("memo.txt")])
+
+        #expect(routes.count == 2)
+        #expect(routes.contains { if case .plaudExport = $0 { true } else { false } })
+        #expect(routes.contains { if case .textOnly(let file) = $0 { file.lastPathComponent == "memo.txt" } else { false } })
+    }
+
+    private func url(_ filename: String) -> URL {
+        URL(fileURLWithPath: "/tmp/ImportRouterTests/\(filename)")
+    }
+}


### PR DESCRIPTION
## 変更概要
- 音声・JSON/TXTをbasenameで自動ルーティング
- 外部レコーダーの作成日時を取り込み時に反映
- 録音デバイス案内とDEBUG限定の非公式API UI

## 確認
- `xcodebuild build -project Memora.xcodeproj -scheme Memora -destination 'generic/platform=iOS Simulator' -configuration Debug -quiet`\n- `xcodebuild test -project Memora.xcodeproj -scheme Memora -destination 'platform=iOS Simulator,id=FEA55307-F00D-4E45-BEFF-8616B312692C' -only-testing:MemoraTests/ImportRouterTests -quiet`\n- Release build / pbxproj lint / diff check\n\n## 未確認\n- 実機でのPLAUD実エクスポートおよびUSBレコーダー実ファイルの目視確認