### PR TITLE
fix: remove App Store auth and paywall blockers

### DIFF
--- a/Memora/App/ContentView.swift
+++ b/Memora/App/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
     @State private var v6Island = V6IslandController()
     @State private var v6RecordingSession = V6RecordingSessionController()
     @State private var v6GenerationSession = V6GenerationSessionController()
-    @AppStorage(V6AuthStorageKey.stage) private var v6AuthStageRaw = V6AuthStage.onboarding.rawValue
+    @AppStorage(V6AuthStorageKey.stage) private var v6AuthStageRaw = V6AuthStage.done.rawValue
     @AppStorage(V6AuthStorageKey.isPro) private var v6IsPro = false
     @AppStorage(V6AuthStorageKey.loginEmail) private var v6LoginEmail = ""
     @Environment(\.modelContext) private var modelContext
@@ -30,7 +30,6 @@ struct ContentView: View {
     @State private var showGenerationProgress = false
     @State private var generatingAudioFile: AudioFile?
     @State private var showFileImporter = false
-    @State private var showV6Paywall = false
     @State private var showMeetingCapture = false
     @State private var meetingCaptureViewModel = MeetingCaptureViewModel()
     @State private var importErrorMessage: String?
@@ -40,7 +39,11 @@ struct ContentView: View {
     }
 
     private var isV6AuthPending: Bool {
+#if DEBUG
         (V6AuthStage(rawValue: v6AuthStageRaw) ?? .onboarding) != .done
+#else
+        false
+#endif
     }
 
     private var showRecordingCover: Binding<Bool> {
@@ -55,7 +58,6 @@ struct ContentView: View {
             NavigationStack {
                 V6AppShellView(
                     selectedTab: $selectedTab,
-                    showPaywall: $showV6Paywall,
                     onStartRecording: {
                         v6RecordingSession.requestPresentation()
                     },

--- a/Memora/Resources/Info.plist
+++ b/Memora/Resources/Info.plist
@@ -42,6 +42,7 @@
 	<string>ウェアラブルデバイスとの接続と音声録音のために Bluetooth を許可してください</string>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>processing</string>
 	</array>
 	<key>NSBluetoothPeripheralUsageDescription</key>

--- a/Memora/Views/V6/V6AppShellView.swift
+++ b/Memora/Views/V6/V6AppShellView.swift
@@ -9,7 +9,6 @@ enum V6HomeFilter {
 
 struct V6AppShellView: View {
     @Binding var selectedTab: Int
-    @Binding var showPaywall: Bool
     let onStartRecording: () -> Void
     let onImport: () -> Void
     let onMeetingCapture: () -> Void
@@ -115,7 +114,6 @@ struct V6AppShellView: View {
         .onChange(of: selectedTab) { _, _ in
             // Tab switching resets any open modal/sheet (`.dc.html`: "activeTab change clears modal/exportOpen").
             isFabMenuOpen = false
-            showPaywall = false
             isHomeFilterMenuOpen = false
             fileMoreMenuTarget = nil
             fileRenameTarget = nil
@@ -126,11 +124,6 @@ struct V6AppShellView: View {
             showPlaudConnection = false
             showDeleteDataConfirm = false
             selectedProject = nil
-        }
-        .sheet(isPresented: $showPaywall) {
-            V6PaywallSheet(isPro: $isPro)
-                .presentationDetents([.large])
-                .presentationDragIndicator(.hidden)
         }
         .sheet(isPresented: $showPlaudConnection) {
             PlaudCloudConnectionSheet()
@@ -564,9 +557,6 @@ struct V6AppShellView: View {
             VStack(alignment: .leading, spacing: 18) {
                 V6SettingsGroup(title: "アカウント") {
                     V6SettingsRow(title: loginEmail.isEmpty ? "未設定" : loginEmail) {}
-                    V6SettingsBadgeRow(title: "プラン", badgeText: isPro ? "Pro" : "Free", badgeColor: isPro ? V6Color.success : V6Color.ink) {
-                        showPaywall = true
-                    }
                 }
 
                 V6SettingsGroup(title: "デバイス") {
@@ -594,9 +584,7 @@ struct V6AppShellView: View {
                 }
 
                 V6SettingsGroup(title: "ストレージ") {
-                    V6SettingsRow(title: "添付の保存先", value: isPro ? "クラウド" : "この端末（Proでクラウド）") {
-                        showPaywall = true
-                    }
+                    V6SettingsStaticRow(title: "添付の保存先", value: "この端末")
                 }
 
                 V6SettingsGroup(title: "通知") {
@@ -1363,6 +1351,26 @@ private struct V6SettingsRow: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+}
+
+private struct V6SettingsStaticRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.system(size: 15))
+                .foregroundStyle(V6Color.ink)
+            Spacer()
+            Text(value)
+                .font(.system(size: 13))
+                .foregroundStyle(V6Color.muted)
+                .lineLimit(1)
+        }
+        .padding(.vertical, 13)
+        .padding(.horizontal, 14)
     }
 }
 

--- a/Memora/Views/V6/V6DynamicIslandPill.swift
+++ b/Memora/Views/V6/V6DynamicIslandPill.swift
@@ -135,41 +135,10 @@ struct V6DynamicIslandPill: View {
     // MARK: - Ask capsule (no answer yet)
 
     private var askNoAnswerContent: some View {
-        HStack(spacing: 10) {
-            Text(island.isAskListening ? "聞き取っています…" : "Search or Ask")
-                .font(.system(size: 15))
-                .foregroundStyle(V6Color.muted)
-                .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            Button {
-                island.startAskListening(
-                    demoQuery: "この前の定例の決定事項をまとめて",
-                    demoAnswer: "2025-01-24 エンジニア定例より:\n・音声データはCloud Storageへ保存\n・要約生成は非同期ジョブに変更",
-                    sourceLabel: "2025-01-24_エンジニア定例"
-                )
-            } label: {
-                ZStack {
-                    if island.isAskListening {
-                        HStack(spacing: 2.5) {
-                            ForEach([11.0, 16.0, 13.0, 15.0], id: \.self) { height in
-                                RoundedRectangle(cornerRadius: 1.5, style: .continuous)
-                                    .fill(.white)
-                                    .frame(width: 2.5, height: height)
-                            }
-                        }
-                    } else {
-                        Image(systemName: "mic.fill")
-                            .font(.system(size: 16))
-                            .foregroundStyle(.white)
-                    }
-                }
-                .frame(width: 44, height: 44)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.leading, 18)
-        .padding(.trailing, 8)
+        Text("Ask は準備中です")
+            .font(.system(size: 15))
+            .foregroundStyle(V6Color.muted)
+            .frame(maxWidth: .infinity, alignment: .center)
     }
 
     // MARK: - Ask capsule (answer)

--- a/apps/mobile-expo/AGENTS.md
+++ b/apps/mobile-expo/AGENTS.md
@@ -11,5 +11,5 @@ Before changing this app, also read:
 Current role of this app:
 
 - Expo Go / web friendly mock UI for fast visual review.
-- Native bridge work is not started yet.
+- Native bridge work is implemented and tracked in Git; keep changes aligned with the bridge contract.
 - Existing Swift STT core and backend must remain untouched unless explicitly requested.


### PR DESCRIPTION
## 概要\n- Releaseでは認証フローを常にスキップし、課金導線を除去\n- Pro/クラウドの未実装訴求をローカル保存表示へ置換\n- Dynamic Islandの固定デモ問答を準備中表示へ置換\n- 録音のバックグラウンド継続をInfo.plistのaudioモードで申告\n- Expo AGENTSのNative bridge状態を実装済みに更新\n\n## 検証\n- xcodegen generate\n- xcodebuild -project Memora.xcodeproj -scheme Memora -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build\n- Release構成の同Simulator build\n- git diff --check\n\nB4は、既存のAVAudioSession(.playAndRecord) / AVAudioRecorder録音セッションに対応してaudioバックグラウンドモードを追加しています。実機の画面ロック中録音は未目視です。