### PR TITLE
RNブリッジで実要約を実行

### DIFF
--- a/apps/mobile-expo/README.md
+++ b/apps/mobile-expo/README.md
@@ -95,8 +95,7 @@ The current native Ask AI query handler is `MemoraSampleKnowledgeQuery` in `modu
 `AskAIScreen` already calls `MemoraNative.queryKnowledge`, and Settings Bridge reports `Knowledge source`.
 Replace it through `MemoraNativeKnowledgeQueryRegistry.knowledgeQuery` from the host app target after deciding the real retrieval/query source of truth. Keep AI provider calls and `KnowledgeQueryService` dependencies outside the local Expo module.
 
-The current native summary handler is `MemoraSampleSummaryGenerator` in `modules/memora-native/ios/MemoraSummaryDTO.swift`.
-`MemoraNative.generateSummary` accepts an `audioFileId` plus provider/template options and returns a JSON-friendly summary DTO. Replace it through `MemoraNativeSummaryRegistry.summaryGenerator` from the host app after deciding the real summary source of truth. Keep `AIService`, provider SDKs, and Keychain dependencies outside the local Expo module.
+The RN host installs `MemoraSharedStoreSummaryGenerator` when the shared SwiftData store is available. It reads the selected provider key from the RN Keychain service (`com.anonymous.memora-rn.ai-credentials`), constructs the provider natively, invokes `MemoraSharedSummary`, and persists the result back to `AudioFile`. `MemoraNative.generateSummary` returns only the JSON-friendly summary DTO; API keys never cross the module boundary. A missing key is an explicit safe error, not a sample fallback.
 
 ## Preview Routes
 

--- a/apps/mobile-expo/ios/MemoraRN.xcodeproj/project.pbxproj
+++ b/apps/mobile-expo/ios/MemoraRN.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		00E356F01AD99517003FC87E /* MemoraSharedStoreBridgeAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F11AD99517003FC87E /* MemoraSharedStoreBridgeAdapterTests.swift */; };
+		C8D4E2F37A2B4C6D8E0F1234 /* MemoraSummaryBridgeSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D4E2F47A2B4C6D8E0F1234 /* MemoraSummaryBridgeSecurityTests.swift */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2B2EC8D499009CD39F3300E6 /* libPods-MemoraRN.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 14F3A3506960F3EA596E3818 /* libPods-MemoraRN.a */; };
 		314DE1AD346D8BFF2B052369 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD038D99E6A0B350A23A8C13 /* ExpoModulesProvider.swift */; };
@@ -16,6 +17,7 @@
 		8944B523367379A8E9FD41F3 /* libPods-MemoraRNTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FF178E45E1B4C487E0376968 /* libPods-MemoraRNTests.a */; };
 		8F12A8F72C7B4A24A6E3A901 /* MemoraNativeBridgeBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F12A8F62C7B4A24A6E3A901 /* MemoraNativeBridgeBootstrap.swift */; };
 		8F12A8F82C7B4A24A6E3A901 /* MemoraSharedStoreBridgeAdapters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F12A8F92C7B4A24A6E3A901 /* MemoraSharedStoreBridgeAdapters.swift */; };
+		C8D4E2F17A2B4C6D8E0F1234 /* MemoraSharedStoreSummaryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D4E2F07A2B4C6D8E0F1234 /* MemoraSharedStoreSummaryGenerator.swift */; };
 		A84D5E6F708192A3B4C5D6E7 /* MemoraRNTranscriptionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84D5E6F708192A3B4C5D6E6 /* MemoraRNTranscriptionBridge.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		CDC318F7BDAF4DB86A44F76C /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF3E027A4D5411EE0F187CAF /* ExpoModulesProvider.swift */; };
@@ -24,6 +26,7 @@
 
 /* Begin PBXFileReference section */
 		00E356F11AD99517003FC87E /* MemoraSharedStoreBridgeAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MemoraSharedStoreBridgeAdapterTests.swift; path = MemoraSharedStoreBridgeAdapterTests.swift; sourceTree = "<group>"; };
+		C8D4E2F47A2B4C6D8E0F1234 /* MemoraSummaryBridgeSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MemoraSummaryBridgeSecurityTests.swift; path = MemoraSummaryBridgeSecurityTests.swift; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* MemoraRNTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MemoraRNTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07F961A680F5B00A75B9A /* MemoraRN.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MemoraRN.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = MemoraRN/Images.xcassets; sourceTree = "<group>"; };
@@ -36,6 +39,7 @@
 		85591F494C3FF612DADCB427 /* Pods-MemoraRN.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MemoraRN.release.xcconfig"; path = "Target Support Files/Pods-MemoraRN/Pods-MemoraRN.release.xcconfig"; sourceTree = "<group>"; };
 		8F12A8F62C7B4A24A6E3A901 /* MemoraNativeBridgeBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MemoraNativeBridgeBootstrap.swift; path = MemoraRN/MemoraNativeBridgeBootstrap.swift; sourceTree = "<group>"; };
 		8F12A8F92C7B4A24A6E3A901 /* MemoraSharedStoreBridgeAdapters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MemoraSharedStoreBridgeAdapters.swift; path = MemoraRN/MemoraSharedStoreBridgeAdapters.swift; sourceTree = "<group>"; };
+		C8D4E2F07A2B4C6D8E0F1234 /* MemoraSharedStoreSummaryGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MemoraSharedStoreSummaryGenerator.swift; path = MemoraRN/MemoraSharedStoreSummaryGenerator.swift; sourceTree = "<group>"; };
 		A84D5E6F708192A3B4C5D6E6 /* MemoraRNTranscriptionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MemoraRNTranscriptionBridge.swift; path = MemoraRN/MemoraRNTranscriptionBridge.swift; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = MemoraRN/SplashScreen.storyboard; sourceTree = "<group>"; };
 		AD038D99E6A0B350A23A8C13 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-MemoraRN/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
@@ -71,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				00E356F11AD99517003FC87E /* MemoraSharedStoreBridgeAdapterTests.swift */,
+				C8D4E2F47A2B4C6D8E0F1234 /* MemoraSummaryBridgeSecurityTests.swift */,
 			);
 			name = MemoraRNTests;
 			path = MemoraRNTests;
@@ -82,6 +87,7 @@
 				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
 				8F12A8F62C7B4A24A6E3A901 /* MemoraNativeBridgeBootstrap.swift */,
 				8F12A8F92C7B4A24A6E3A901 /* MemoraSharedStoreBridgeAdapters.swift */,
+				C8D4E2F07A2B4C6D8E0F1234 /* MemoraSharedStoreSummaryGenerator.swift */,
 				A84D5E6F708192A3B4C5D6E6 /* MemoraRNTranscriptionBridge.swift */,
 				F11748442D0722820044C1D9 /* MemoraRN-Bridging-Header.h */,
 				BB2F792B24A3F905000567C9 /* Supporting */,
@@ -226,6 +232,7 @@
 			packageProductDependencies = (
 				B1C2D3E4F5061728394A5B6C /* MemoraSharedData */,
 				A84D5E6F708192A3B4C5D6E8 /* MemoraSharedCore */,
+				C8D4E2F27A2B4C6D8E0F1234 /* MemoraSharedSummary */,
 			);
 			productName = MemoraRN;
 			productReference = 13B07F961A680F5B00A75B9A /* MemoraRN.app */;
@@ -498,6 +505,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				00E356F01AD99517003FC87E /* MemoraSharedStoreBridgeAdapterTests.swift in Sources */,
+				C8D4E2F37A2B4C6D8E0F1234 /* MemoraSummaryBridgeSecurityTests.swift in Sources */,
 				CDC318F7BDAF4DB86A44F76C /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -509,6 +517,7 @@
 				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
 				8F12A8F72C7B4A24A6E3A901 /* MemoraNativeBridgeBootstrap.swift in Sources */,
 				8F12A8F82C7B4A24A6E3A901 /* MemoraSharedStoreBridgeAdapters.swift in Sources */,
+				C8D4E2F17A2B4C6D8E0F1234 /* MemoraSharedStoreSummaryGenerator.swift in Sources */,
 				A84D5E6F708192A3B4C5D6E7 /* MemoraRNTranscriptionBridge.swift in Sources */,
 				314DE1AD346D8BFF2B052369 /* ExpoModulesProvider.swift in Sources */,
 			);
@@ -810,6 +819,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A1B2C3D4E5F60718293A4B5C /* XCLocalSwiftPackageReference "MemoraSharedData" */;
 			productName = MemoraSharedCore;
+		};
+		C8D4E2F27A2B4C6D8E0F1234 /* MemoraSharedSummary */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A1B2C3D4E5F60718293A4B5C /* XCLocalSwiftPackageReference "MemoraSharedData" */;
+			productName = MemoraSharedSummary;
 		};
 		B1C2D3E4F5061728394A5B6C /* MemoraSharedData */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/apps/mobile-expo/ios/MemoraRN/MemoraNativeBridgeBootstrap.swift
+++ b/apps/mobile-expo/ios/MemoraRN/MemoraNativeBridgeBootstrap.swift
@@ -3,6 +3,7 @@ import SwiftData
 internal import MemoraNative
 import MemoraSharedData
 import MemoraSharedSchema
+import MemoraSharedSummary
 
 @MainActor
 enum MemoraNativeBridgeBootstrap {
@@ -18,7 +19,7 @@ enum MemoraNativeBridgeBootstrap {
       recordingImportHandler: MemoraNativeFileRecordingImportHandler(),
       settingsStore: MemoraUserDefaultsSettingsStore(),
       knowledgeQuery: MemoraSampleKnowledgeQuery(),
-      summaryGenerator: MemoraSampleSummaryGenerator()
+      summaryGenerator: MemoraUnavailableSummaryGenerator()
     )
     MemoraNativePlaybackRegistry.controller = MemoraAVAudioPlaybackController()
     MemoraNativeMemoRegistry.memoHandler = MemoraNativeFileMemoStore()
@@ -82,6 +83,7 @@ enum MemoraNativeBridgeBootstrap {
     MemoraNativeAudioFileReaderRegistry.audioFileReader = adapter
     MemoraNativeAudioFileMutationRegistry.audioFileMutator = adapter
     MemoraNativeTranscriptionRegistry.handler = transcriptionHandler
+    MemoraNativeSummaryRegistry.summaryGenerator = MemoraSharedStoreSummaryGenerator(container: container)
     if let recordingImportHandler {
       MemoraNativeRecordingImportRegistry.handler = recordingImportHandler
     }

--- a/apps/mobile-expo/ios/MemoraRN/MemoraSharedStoreSummaryGenerator.swift
+++ b/apps/mobile-expo/ios/MemoraRN/MemoraSharedStoreSummaryGenerator.swift
@@ -1,0 +1,282 @@
+import Foundation
+import Security
+import SwiftData
+internal import MemoraNative
+import MemoraSharedCore
+import MemoraSharedSchema
+import MemoraSharedSummary
+
+/// RNホストだけが読むAI認証情報。値はこのファイル外へ返さない。
+protocol MemoraRNSummaryKeyReading {
+  func apiKey(for provider: MemoraRNSummaryProvider) throws -> String?
+}
+
+enum MemoraRNSummaryProvider: String {
+  case openAI = "OpenAI"
+  case gemini = "Gemini"
+  case deepSeek = "DeepSeek"
+  case local = "Local"
+
+  init?(bridgeValue: String) {
+    self.init(rawValue: bridgeValue)
+  }
+
+  var keychainAccount: String? {
+    switch self {
+    case .openAI: return "openai-api-key"
+    case .gemini: return "gemini-api-key"
+    case .deepSeek: return "deepseek-api-key"
+    case .local: return nil
+    }
+  }
+}
+
+struct MemoraRNKeychainSummaryKeyReader: MemoraRNSummaryKeyReading {
+  private static let service = "com.anonymous.memora-rn.ai-credentials"
+
+  func apiKey(for provider: MemoraRNSummaryProvider) throws -> String? {
+    guard let account = provider.keychainAccount else { return nil }
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: Self.service,
+      kSecAttrAccount as String: account,
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne
+    ]
+    var result: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    if status == errSecItemNotFound { return nil }
+    guard status == errSecSuccess, let data = result as? Data else {
+      throw MemoraRNSummaryError.apiKeyUnavailable
+    }
+    return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+enum MemoraRNSummaryError: LocalizedError {
+  case invalidAudioFileID
+  case audioFileNotFound
+  case transcriptUnavailable
+  case providerUnsupported
+  case apiKeyMissing
+  case apiKeyUnavailable
+  case generationFailed
+  case saveFailed
+
+  var errorDescription: String? {
+    switch self {
+    case .invalidAudioFileID: return "要約対象のファイルを識別できません。"
+    case .audioFileNotFound: return "要約対象のファイルが見つかりません。"
+    case .transcriptUnavailable: return "文字起こしがないため要約を生成できません。"
+    case .providerUnsupported: return "選択した要約プロバイダーは利用できません。"
+    case .apiKeyMissing: return "選択したプロバイダーのAPIキーが設定されていません。"
+    case .apiKeyUnavailable: return "APIキーを読み取れません。設定を確認してください。"
+    case .generationFailed: return "要約の生成に失敗しました。時間をおいてもう一度お試しください。"
+    case .saveFailed: return "要約結果を保存できませんでした。"
+    }
+  }
+}
+
+@MainActor
+final class MemoraSharedStoreSummaryGenerator: MemoraSummaryGenerating {
+  let sourceDescription = "swiftdata"
+
+  private let container: ModelContainer
+  private let keyReader: any MemoraRNSummaryKeyReading
+  private let providerFactory: (MemoraRNSummaryProvider, String) throws -> any LLMProvider
+
+  init(
+    container: ModelContainer,
+    keyReader: any MemoraRNSummaryKeyReading = MemoraRNKeychainSummaryKeyReader(),
+    providerFactory: @escaping (MemoraRNSummaryProvider, String) throws -> any LLMProvider = MemoraRNRemoteLLMProvider.make
+  ) {
+    self.container = container
+    self.keyReader = keyReader
+    self.providerFactory = providerFactory
+  }
+
+  func generateSummary(_ request: MemoraSummaryRequestDTO) async throws -> MemoraSummaryDTO {
+    guard let audioFileID = UUID(uuidString: request.audioFileId) else {
+      throw MemoraRNSummaryError.invalidAudioFileID
+    }
+    guard let provider = MemoraRNSummaryProvider(bridgeValue: request.options.provider), provider != .local else {
+      throw MemoraRNSummaryError.providerUnsupported
+    }
+
+    let context = ModelContext(container)
+    let descriptor = FetchDescriptor<AudioFile>(predicate: #Predicate { $0.id == audioFileID })
+    guard let audioFile = try? context.fetch(descriptor).first else {
+      throw MemoraRNSummaryError.audioFileNotFound
+    }
+    guard let transcript = audioFile.transcripts.first?.text.trimmingCharacters(in: .whitespacesAndNewlines), !transcript.isEmpty else {
+      throw MemoraRNSummaryError.transcriptUnavailable
+    }
+
+    let apiKey: String
+    do {
+      guard let storedKey = try keyReader.apiKey(for: provider), !storedKey.isEmpty else {
+        throw MemoraRNSummaryError.apiKeyMissing
+      }
+      apiKey = storedKey
+    } catch let error as MemoraRNSummaryError {
+      throw error
+    } catch {
+      throw MemoraRNSummaryError.apiKeyUnavailable
+    }
+
+    let llmProvider: any LLMProvider
+    do {
+      llmProvider = try providerFactory(provider, apiKey)
+    } catch {
+      throw MemoraRNSummaryError.providerUnsupported
+    }
+
+    let engine = SummarizationEngine()
+    engine.configure(provider: llmProvider)
+    let result: SummaryResult
+    do {
+      result = try await engine.summarize(transcript: transcript)
+    } catch {
+      throw MemoraRNSummaryError.generationFailed
+    }
+
+    audioFile.summary = result.summary
+    audioFile.keyPoints = result.keyPointsText
+    audioFile.actionItems = result.actionItemsText
+    audioFile.isSummarized = true
+    do {
+      try context.save()
+    } catch {
+      throw MemoraRNSummaryError.saveFailed
+    }
+
+    return MemoraSummaryDTO(
+      audioFileId: audioFile.id.uuidString,
+      text: result.summary,
+      generatedAt: Date(),
+      provider: provider.rawValue
+    )
+  }
+}
+
+private struct MemoraRNRemoteLLMProvider: LLMProvider {
+  let displayName: String
+  private let provider: MemoraRNSummaryProvider
+  private let apiKey: String
+  private let session: URLSession
+
+  static func make(provider: MemoraRNSummaryProvider, apiKey: String) throws -> any LLMProvider {
+    switch provider {
+    case .openAI, .gemini, .deepSeek:
+      return Self(provider: provider, apiKey: apiKey)
+    case .local:
+      throw MemoraRNSummaryError.providerUnsupported
+    }
+  }
+
+  private init(provider: MemoraRNSummaryProvider, apiKey: String) {
+    self.provider = provider
+    self.apiKey = apiKey
+    self.displayName = provider.rawValue
+    let configuration = URLSessionConfiguration.default
+    configuration.timeoutIntervalForRequest = 120
+    self.session = URLSession(configuration: configuration)
+  }
+
+  func generate(_ prompt: String) async throws -> String {
+    try await requestContent(prompt: prompt, includeSummaryInstruction: false)
+  }
+
+  func summarize(transcript: String) async throws -> LLMProviderSummary {
+    let content = try await requestContent(prompt: Self.summaryPrompt(transcript: transcript), includeSummaryInstruction: true)
+    guard let data = content.data(using: .utf8),
+          let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let summary = json["summary"] as? String,
+          let keyPoints = json["keyPoints"] as? [String],
+          let actionItems = json["actionItems"] as? [String] else {
+      throw LLMProviderError.decodingError
+    }
+    return LLMProviderSummary(
+      title: json["title"] as? String,
+      summary: summary,
+      keyPoints: keyPoints,
+      actionItems: actionItems
+    )
+  }
+
+  private func requestContent(prompt: String, includeSummaryInstruction: Bool) async throws -> String {
+    var request: URLRequest
+    switch provider {
+    case .openAI, .deepSeek:
+      let baseURL = provider == .openAI ? "https://api.openai.com/v1" : "https://api.deepseek.com/v1"
+      let model = provider == .openAI ? "gpt-4o-mini" : "deepseek-chat"
+      request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+      request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+      var messages: [[String: String]] = []
+      if includeSummaryInstruction {
+        messages.append(["role": "system", "content": "あなたは会議の文字起こしから要約を作成するアシスタントです。"])
+      }
+      messages.append(["role": "user", "content": prompt])
+      request.httpBody = try JSONSerialization.data(withJSONObject: [
+        "model": model,
+        "messages": messages,
+        "temperature": 0.3,
+        "max_tokens": 2048
+      ])
+    case .gemini:
+      var components = URLComponents(string: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent")!
+      components.queryItems = [URLQueryItem(name: "key", value: apiKey)]
+      request = URLRequest(url: components.url!)
+      let text = includeSummaryInstruction
+        ? "あなたは会議の文字起こしから要約を作成するアシスタントです。\n\n\(prompt)"
+        : prompt
+      request.httpBody = try JSONSerialization.data(withJSONObject: [
+        "contents": [["parts": [["text": text]]]],
+        "generationConfig": ["temperature": 0.3, "topK": 1, "topP": 1]
+      ])
+    case .local:
+      throw MemoraRNSummaryError.providerUnsupported
+    }
+
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    let (data, response) = try await session.data(for: request)
+    guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+      throw LLMProviderError.invalidResponse
+    }
+
+    let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    if provider == .gemini {
+      guard let candidates = object?["candidates"] as? [[String: Any]],
+            let content = candidates.first?["content"] as? [String: Any],
+            let parts = content["parts"] as? [[String: Any]],
+            let text = parts.first?["text"] as? String else {
+        throw LLMProviderError.decodingError
+      }
+      return text
+    }
+    guard let choices = object?["choices"] as? [[String: Any]],
+          let message = choices.first?["message"] as? [String: Any],
+          let content = message["content"] as? String else {
+      throw LLMProviderError.decodingError
+    }
+    return content
+  }
+
+  private static func summaryPrompt(transcript: String) -> String {
+    """
+    以下の会議 transcript から、タイトル、要約、重要ポイント、アクションアイテムを抽出してください。
+    出力は以下のJSON形式で返してください：
+
+    {
+      "title": "会議内容を表す簡潔なタイトル（20字以内）",
+      "summary": "会議の要約",
+      "keyPoints": ["重要ポイント1", "重要ポイント2"],
+      "actionItems": ["アクションアイテム1", "アクションアイテム2"]
+    }
+
+    Transcript:
+    \(transcript)
+    """
+  }
+}

--- a/apps/mobile-expo/ios/MemoraRNTests/MemoraSummaryBridgeSecurityTests.swift
+++ b/apps/mobile-expo/ios/MemoraRNTests/MemoraSummaryBridgeSecurityTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import MemoraRN
+internal import MemoraNative
+import MemoraSharedCore
+import MemoraSharedSchema
+
+private struct SecretFailingKeyReader: MemoraRNSummaryKeyReading {
+  let secret: String
+
+  func apiKey(for provider: MemoraRNSummaryProvider) throws -> String? {
+    throw SyntheticKeychainError.message(secret)
+  }
+}
+
+private enum SyntheticKeychainError: Error {
+  case message(String)
+}
+
+private struct FixedKeyReader: MemoraRNSummaryKeyReading {
+  func apiKey(for provider: MemoraRNSummaryProvider) throws -> String? { "native-only-test-key" }
+}
+
+private struct SummaryProviderStub: LLMProvider {
+  let displayName = "Test"
+
+  func generate(_ prompt: String) async throws -> String { "" }
+
+  func summarize(transcript: String) async throws -> LLMProviderSummary {
+    LLMProviderSummary(
+      title: "テスト要約",
+      summary: "共有要約コアの結果",
+      keyPoints: ["要点"],
+      actionItems: ["対応"]
+    )
+  }
+}
+
+@Suite("RN summary bridge security")
+struct MemoraSummaryBridgeSecurityTests {
+  @Test("Keychain失敗とDTOは秘密文字列をJS境界へ出さない")
+  @MainActor
+  func doesNotExposeAPIKey() async throws {
+    let secret = "rn-summary-test-secret-not-for-js"
+    let storeURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("memora-rn-summary-security-\(UUID().uuidString).store")
+    defer { try? FileManager.default.removeItem(at: storeURL) }
+
+    let container = try MemoraSharedStoreFactory.makePersistentContainer(at: storeURL)
+    let context = ModelContext(container)
+    let audioFile = AudioFile(title: "Security test", audioURL: "/tmp/security.m4a")
+    let transcript = Transcript(audioFileID: audioFile.id, text: "文字起こし")
+    transcript.audioFile = audioFile
+    context.insert(audioFile)
+    context.insert(transcript)
+    try context.save()
+
+    let generator = MemoraSharedStoreSummaryGenerator(
+      container: container,
+      keyReader: SecretFailingKeyReader(secret: secret)
+    )
+    let request = MemoraSummaryRequestDTO(dictionary: [
+      "audioFileId": audioFile.id.uuidString,
+      "options": ["provider": "Gemini"]
+    ])
+
+    do {
+      _ = try await generator.generateSummary(request)
+      Issue.record("Keychain読み取り失敗は明示エラーである必要があります")
+    } catch {
+      #expect(error.localizedDescription.contains(secret) == false)
+      #expect(error.localizedDescription == MemoraRNSummaryError.apiKeyUnavailable.localizedDescription)
+    }
+
+    let dto = MemoraSummaryDTO(
+      audioFileId: audioFile.id.uuidString,
+      text: "要約本文",
+      generatedAt: Date(timeIntervalSince1970: 0),
+      provider: "Gemini"
+    ).asDictionary()
+    #expect(dto.values.contains { "\($0)".contains(secret) } == false)
+  }
+
+  @Test("共有要約結果をSwiftDataへ保存する")
+  @MainActor
+  func savesGeneratedSummary() async throws {
+    let storeURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("memora-rn-summary-save-\(UUID().uuidString).store")
+    defer { try? FileManager.default.removeItem(at: storeURL) }
+
+    let container = try MemoraSharedStoreFactory.makePersistentContainer(at: storeURL)
+    let context = ModelContext(container)
+    let audioFile = AudioFile(title: "Save test", audioURL: "/tmp/save.m4a")
+    let transcript = Transcript(audioFileID: audioFile.id, text: "保存対象の文字起こし")
+    transcript.audioFile = audioFile
+    context.insert(audioFile)
+    context.insert(transcript)
+    try context.save()
+
+    let generator = MemoraSharedStoreSummaryGenerator(
+      container: container,
+      keyReader: FixedKeyReader(),
+      providerFactory: { _, _ in SummaryProviderStub() }
+    )
+    let result = try await generator.generateSummary(MemoraSummaryRequestDTO(dictionary: [
+      "audioFileId": audioFile.id.uuidString,
+      "options": ["provider": "Gemini"]
+    ]))
+
+    #expect(result.text == "共有要約コアの結果")
+    #expect(audioFile.summary == "共有要約コアの結果")
+    #expect(audioFile.keyPoints == "要点")
+    #expect(audioFile.actionItems == "対応")
+    #expect(audioFile.isSummarized)
+  }
+}

--- a/apps/mobile-expo/modules/memora-native/ios/MemoraNativeModule.swift
+++ b/apps/mobile-expo/modules/memora-native/ios/MemoraNativeModule.swift
@@ -83,8 +83,8 @@ public class MemoraNativeModule: Module {
         .asDictionary()
     }
 
-    AsyncFunction("generateSummary") { (request: [String: Any]) -> [String: Any] in
-      try self.summaryGenerator
+    AsyncFunction("generateSummary") { (request: [String: Any]) async throws -> [String: Any] in
+      try await self.summaryGenerator
         .generateSummary(MemoraSummaryRequestDTO(dictionary: request))
         .asDictionary()
     }

--- a/apps/mobile-expo/modules/memora-native/ios/MemoraSummaryDTO.swift
+++ b/apps/mobile-expo/modules/memora-native/ios/MemoraSummaryDTO.swift
@@ -28,6 +28,13 @@ public struct MemoraSummaryDTO {
   public let generatedAt: Date
   public let provider: String
 
+  public init(audioFileId: String, text: String, generatedAt: Date, provider: String) {
+    self.audioFileId = audioFileId
+    self.text = text
+    self.generatedAt = generatedAt
+    self.provider = provider
+  }
+
   public func asDictionary() -> [String: Any] {
     [
       "audioFileId": audioFileId,
@@ -41,24 +48,30 @@ public struct MemoraSummaryDTO {
 public protocol MemoraSummaryGenerating {
   var sourceDescription: String { get }
 
-  func generateSummary(_ request: MemoraSummaryRequestDTO) throws -> MemoraSummaryDTO
+  func generateSummary(_ request: MemoraSummaryRequestDTO) async throws -> MemoraSummaryDTO
 }
 
 public enum MemoraNativeSummaryRegistry {
-  public static var summaryGenerator: MemoraSummaryGenerating = MemoraSampleSummaryGenerator()
+  public static var summaryGenerator: MemoraSummaryGenerating = MemoraUnavailableSummaryGenerator()
 }
 
-public struct MemoraSampleSummaryGenerator: MemoraSummaryGenerating {
-  public let sourceDescription = "sample"
+public struct MemoraUnavailableSummaryGenerator: MemoraSummaryGenerating {
+  public let sourceDescription = "native"
 
   public init() {}
 
-  public func generateSummary(_ request: MemoraSummaryRequestDTO) throws -> MemoraSummaryDTO {
-    MemoraSummaryDTO(
-      audioFileId: request.audioFileId,
-      text: "Native bridge sample summary is ready for the host-app summarizer.",
-      generatedAt: Date(),
-      provider: request.options.provider
-    )
+  public func generateSummary(_ request: MemoraSummaryRequestDTO) async throws -> MemoraSummaryDTO {
+    throw MemoraSummaryBridgeError.sharedStoreUnavailable
+  }
+}
+
+public enum MemoraSummaryBridgeError: LocalizedError {
+  case sharedStoreUnavailable
+
+  public var errorDescription: String? {
+    switch self {
+    case .sharedStoreUnavailable:
+      return "要約を利用できません。データストアに接続してからもう一度お試しください。"
+    }
   }
 }

--- a/apps/mobile-expo/src/native/BRIDGE_CONTRACT.md
+++ b/apps/mobile-expo/src/native/BRIDGE_CONTRACT.md
@@ -485,8 +485,9 @@ type SummaryRequestDTO = {
 ```
 
 The current Swift boundary is `MemoraSummaryGenerating`, registered through `MemoraNativeSummaryRegistry.summaryGenerator`.
-The sample implementation is intentionally deterministic. The first real summary pass should inject a host-app adapter through `MemoraNativeBridgeBootstrap.configure(...)` after the summary source of truth and provider ownership are decided.
-Do not call `AIService`, provider SDKs, or Keychain directly from the local Expo module.
+When the RN host opens the shared SwiftData store, `MemoraSharedStoreSummaryGenerator` is installed and reports `summarySource: 'swiftdata'`. It obtains the transcript and `AudioFile`, reads the selected provider key only from the RN Keychain service, constructs the provider in the host target, invokes `MemoraSharedSummary`, then persists `summary`, `keyPoints`, `actionItems`, and `isSummarized`.
+
+The DTO, events, logs, and errors must never include an API key. Missing keys and unavailable shared storage return explicit safe errors; they must not fall back to sample output. Do not call provider clients or Keychain from the local Expo module.
 
 ## Verification Log
 


### PR DESCRIPTION
## 概要
- RN共有SwiftDataストアから文字起こしを読み、共有要約コアで実要約を実行
- RN専用Keychainから選択プロバイダーの鍵をネイティブ内で取得
- summary/keyPoints/actionItems/isSummarized をSwiftDataへ保存
- 固定サンプルを安全な明示エラーへ置換

## セキュリティ
- APIキーは共有パッケージ、JS、DTO、イベント、ログ、エラー本文へ渡さない
- 鍵未設定は明示エラーで、サンプルへのフォールバックなし

## 検証
- npm run typecheck
- npm run qa:ios:build
- swift test --package-path Packages/MemoraSharedData
- xcodegen generate / Memora Simulator build-for-testing
- RN要約ブリッジの鍵漏洩・SwiftData保存テストを追加