### PR TITLE
feat: salvage Plaud import core improvements

### DIFF
--- a/Memora/Core/Services/AudioFileImportService.swift
+++ b/Memora/Core/Services/AudioFileImportService.swift
@@ -47,6 +47,9 @@ enum AudioFileImportService {
 
         let audioFile = AudioFile(title: resolvedTitle, audioURL: destinationURL.path)
         audioFile.duration = durationSeconds.isFinite ? durationSeconds : 0
+        if let creationDate = try? sourceURL.resourceValues(forKeys: [.creationDateKey]).creationDate {
+            audioFile.createdAt = creationDate
+        }
 
         modelContext.insert(audioFile)
         try modelContext.save()

--- a/Memora/Views/Settings/DeveloperFeaturesSection.swift
+++ b/Memora/Views/Settings/DeveloperFeaturesSection.swift
@@ -5,16 +5,19 @@ import SwiftData
 
 struct DeveloperFeaturesSection: View {
     @Bindable var state: SettingsState
+#if DEBUG
     @Environment(\.modelContext) private var modelContext
     @Query private var plaudSettingsList: [PlaudSettings]
 
     private var plaudSettings: PlaudSettings? {
         plaudSettingsList.first
     }
+#endif
 
     var body: some View {
         Section {
-            // PLAUD cloud import
+#if DEBUG
+            // 非公式 API を使う開発用のログイン・同期 UI
             VStack(alignment: .leading, spacing: 8) {
                 HStack {
                     Image(systemName: "icloud.and.arrow.down")
@@ -26,6 +29,7 @@ struct DeveloperFeaturesSection: View {
                     .font(MemoraTypography.caption1)
                     .foregroundStyle(.secondary)
             }
+#endif
 
             // Gemma 4 Experimental
             VStack(alignment: .leading, spacing: MemoraSpacing.sm) {
@@ -97,6 +101,8 @@ struct DeveloperFeaturesSection: View {
             }
             .padding(.vertical, MemoraSpacing.xxxs)
 
+#if DEBUG
+            // 非公式 API を使う開発用のログイン・同期 UI
             // Plaud 連携 Toggle
             Toggle("Plaud 連携を有効化", isOn: Binding(
                 get: { plaudSettings?.isEnabled ?? false },
@@ -120,12 +126,16 @@ struct DeveloperFeaturesSection: View {
             if plaudSettings?.isEnabled ?? false {
                 plaudSettingsContent
             }
+#endif
         }
+        #if DEBUG
         .task {
             state.isLoggedIn = PlaudMCPOAuthService().account().isConnected
         }
+        #endif
     }
 
+#if DEBUG
     @ViewBuilder
     private var plaudSettingsContent: some View {
         if state.isLoggedIn {
@@ -261,4 +271,5 @@ struct DeveloperFeaturesSection: View {
         formatter.locale = Locale(identifier: "ja_JP")
         return formatter.string(from: date)
     }
+#endif
 }

--- a/Memora/Views/Settings/DeviceConnectionSection.swift
+++ b/Memora/Views/Settings/DeviceConnectionSection.swift
@@ -16,6 +16,14 @@ struct DeviceConnectionSection: View {
 
     var body: some View {
         Section {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Omi は Bluetooth Low Energy（BLE）で直接接続します。")
+                    .font(MemoraTypography.caption1)
+                Text("PLAUDなどのレコーダーは、各アプリやFilesから書き出した音声・JSON・TXTファイルをホームのファイル読み込みで取り込めます。")
+                    .font(MemoraTypography.caption1)
+                    .foregroundStyle(.secondary)
+            }
+
             if let omiAdapter, !omiAdapter.sdkAvailable {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Omi Swift SDK が未設定です")
@@ -146,7 +154,7 @@ struct DeviceConnectionSection: View {
                 }
             }
         } header: {
-            GlassSectionHeader(title: "Omi 接続", icon: "headphones")
+            GlassSectionHeader(title: "録音デバイス", icon: "headphones")
         }
     }
 }


### PR DESCRIPTION
## 概要
#81 から生存するPlaud取り込みコアのみを救出します。

- 取り込み元ファイルの作成日時を保持
- 設定の録音デバイス説明を現行RNホームのファイル取り込み導線に合わせて更新
- 非公式Plaud APIのログイン・同期UIを `#if DEBUG` に限定

## 審査対策
非公式API UIのDebug限定化は、出荷ビルドから第三者サービスへの無許可アクセス経路を除外するための審査対策（App Review Guidelines 5.2.2）です。

## 検証
- `xcodegen generate`
- 署名なしSimulator Debug build
- 署名なしSimulator Release build
- `git diff --check`