### PR TITLE
feat: guard recording against low disk space

### DIFF
--- a/Memora.xcodeproj/project.pbxproj
+++ b/Memora.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		81AEF1450AF431174E12F315 /* MeetingCaptureProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27BAF7EBFD53226A2B45B367 /* MeetingCaptureProgressView.swift */; };
 		833D0D3B34276CA570577805 /* AudioFileRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B0E6085A202875DA87BBF8 /* AudioFileRow.swift */; };
 		8375E72353D31B6559872467 /* NotionIntegrationSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D29E695672907D45D929D22 /* NotionIntegrationSection.swift */; };
+		85757F2B3ECC19D0F5B64CAD /* RecordingDiskSpaceGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4976D5159028DADE63B74B35 /* RecordingDiskSpaceGuardTests.swift */; };
 		85A93595444BB9CDCD6E5B14 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9B239A10FD480509DFB57B /* ShareSheet.swift */; };
 		85FEAA20061453D62AB6BA2B /* ExpandableGlassEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76AE5E37F76567438836EDEC /* ExpandableGlassEffect.swift */; };
 		87AAFF280720E9CF570F19F9 /* TaskPlannerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFBD0F5F237593A207E44875 /* TaskPlannerService.swift */; };
@@ -159,6 +160,7 @@
 		ABA75B650BF5A87DE3741076 /* MemoraSharedAudioFileStoreAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1595E0DB88E7843DA433911 /* MemoraSharedAudioFileStoreAdapterTests.swift */; };
 		AC077218DC20C6F70A9DEF1F /* V6AccountPlanSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0850111EF75C27905C2B8ADA /* V6AccountPlanSection.swift */; };
 		AED883C46A40DBD106C487A7 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95E55698D7A418A8FC30D32 /* EmptyStateView.swift */; };
+		AF2ACD9F94E7DC45AEF44D0C /* RecordingDiskSpaceGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F50ED0E9BF0BD431653FE2 /* RecordingDiskSpaceGuard.swift */; };
 		B289435D7C45DCB84E2E1031 /* NothingTabPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB27B6DAAB0BDC34E0BBAF5 /* NothingTabPicker.swift */; };
 		B2B4C6FCF960E174D7948F9D /* APIKeySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD7331935FC980D189F38A5 /* APIKeySection.swift */; };
 		B3859A53C684BAFCA2721EAE /* TodoItemSummarySaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D97A2BA6E2577405EE4E11E0 /* TodoItemSummarySaver.swift */; };
@@ -308,6 +310,7 @@
 		4261F1B68C2F943A7586DB5F /* GoogleMeetSettings+Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GoogleMeetSettings+Keychain.swift"; sourceTree = "<group>"; };
 		427F55F56EF19B78D3165265 /* PlaudMCPTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaudMCPTypes.swift; sourceTree = "<group>"; };
 		491305817A04792B920C84DE /* MemoraAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoraAnimation.swift; sourceTree = "<group>"; };
+		4976D5159028DADE63B74B35 /* RecordingDiskSpaceGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingDiskSpaceGuardTests.swift; sourceTree = "<group>"; };
 		4A11A114A2A24DDFC2D7057B /* TranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTests.swift; sourceTree = "<group>"; };
 		4C2E849B4772C55BF6F4876C /* MeetingWebhookReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingWebhookReceiver.swift; sourceTree = "<group>"; };
 		4C98E1AAF0F819D596219AF0 /* TranscriptionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionEngine.swift; sourceTree = "<group>"; };
@@ -459,6 +462,7 @@
 		F76FDEBF007388E9359C830B /* PersistentStoreSafetyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentStoreSafetyService.swift; sourceTree = "<group>"; };
 		F780FEDD2F07DC45648DD79C /* SpeakerProfileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerProfileStore.swift; sourceTree = "<group>"; };
 		F848386F9F51426F48C6975B /* CalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarService.swift; sourceTree = "<group>"; };
+		F8F50ED0E9BF0BD431653FE2 /* RecordingDiskSpaceGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingDiskSpaceGuard.swift; sourceTree = "<group>"; };
 		F976DECF01B7B80665AE885F /* LocalDataDeletionServiceCoverageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalDataDeletionServiceCoverageTests.swift; sourceTree = "<group>"; };
 		FA7E242D95B2B86EDB58ECD4 /* GoogleAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAuthService.swift; sourceTree = "<group>"; };
 		FDC6535DDE4D1AFC10D90EE8 /* TemplateSelectSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateSelectSheet.swift; sourceTree = "<group>"; };
@@ -676,6 +680,7 @@
 				427F55F56EF19B78D3165265 /* PlaudMCPTypes.swift */,
 				78A39563D755711D640B86DA /* PlaudService.swift */,
 				6BA50970588243441120B0E9 /* ProcessingStatusCenter.swift */,
+				F8F50ED0E9BF0BD431653FE2 /* RecordingDiskSpaceGuard.swift */,
 				683BDDF7F5D7217B9B39D628 /* RemoteLLMProvider.swift */,
 				7E12022A7B46A8A00E26F7B8 /* SegmentedAudioFileResolver.swift */,
 				058B06299797571747E4B64C /* SpeakerDiarizationService.swift */,
@@ -863,6 +868,7 @@
 				855C85865B09046C10B73313 /* OpenAIExportServiceTests.swift */,
 				AF106F713A7D8A1486AD89C3 /* PersistentStoreSafetyServiceTests.swift */,
 				A22A7FA247F81475BB0ED07E /* PipelineReferenceDataTests.swift */,
+				4976D5159028DADE63B74B35 /* RecordingDiskSpaceGuardTests.swift */,
 				E0ED0108BC9A5810D057A9E8 /* STTPreflightTests.swift */,
 				3DE72288623660E9D5CC5449 /* STTServiceDependencyInjectionTests.swift */,
 				EFB351463211868036AE25D4 /* STTServiceRecoveryTests.swift */,
@@ -1159,6 +1165,7 @@
 				EC8EB5AC0D4F467DC0F59E63 /* PlaudCloudSyncLedgerTests.swift in Sources */,
 				4E6D4F58ACEEDCBEBD180442 /* PlaudMCPTypesTests.swift in Sources */,
 				C2240CA7F45DE5392524341F /* ProjectsViewModelTests.swift in Sources */,
+				85757F2B3ECC19D0F5B64CAD /* RecordingDiskSpaceGuardTests.swift in Sources */,
 				7EAA607ED871E0A46CD65BE0 /* STTPreflightTests.swift in Sources */,
 				4A5A804D7BB2F4016F1B8499 /* STTServiceDependencyInjectionTests.swift in Sources */,
 				A00298FFEBFCD28FD2539F3C /* STTServiceRecoveryTests.swift in Sources */,
@@ -1312,6 +1319,7 @@
 				7F290601D5EB11908360BE1A /* ProjectRepository.swift in Sources */,
 				95F93D2BCDA772CA23A51C95 /* ProjectsViewModel.swift in Sources */,
 				18F1574329612A74A422B0CB /* RealtimeTranscriptionSection.swift in Sources */,
+				AF2ACD9F94E7DC45AEF44D0C /* RecordingDiskSpaceGuard.swift in Sources */,
 				9E0C9CEEC8798C46CAEB7D44 /* RecordingViewModel.swift in Sources */,
 				933327D42D86BC079CC744FC /* RemoteLLMProvider.swift in Sources */,
 				979F9BCB1F74304FBFF5B810 /* STTCapabilityHostDependencies.swift in Sources */,

--- a/Memora/Core/Services/AudioRecorder.swift
+++ b/Memora/Core/Services/AudioRecorder.swift
@@ -47,9 +47,15 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
     private var recordingFileID: UUID?
     private var completedSegmentURLs: [URL] = []
     private var completedSegmentDuration: TimeInterval = 0
+    private var terminalResult: RecordingResult?
+    private var didSurfaceLowDiskWarning = false
+    private let diskSpaceGuard: RecordingDiskSpaceGuard
     /// Called only after a segment has been closed, so callers can persist the
     /// recoverable prefix before a subsequent segment begins.
     var completedSegmentsDidChange: (([URL]) -> Void)?
+    /// Delivered at most once for a low-space warning, or once when recording
+    /// is safely stopped before opening a new segment.
+    var diskSpaceDidChange: ((RecordingDiskSpaceDecision) -> Void)?
     private var levelContinuations: [UUID: AsyncStream<Float>.Continuation] = [:]
     private var meteringTimer: Timer?
     private var shouldResumeAfterInterruption = false
@@ -58,7 +64,8 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
 
     var primaryRecordingURL: URL? { firstRecordingURL }
 
-    override init() {
+    init(diskSpaceGuard: RecordingDiskSpaceGuard = RecordingDiskSpaceGuard()) {
+        self.diskSpaceGuard = diskSpaceGuard
         super.init()
         observeAudioSessionNotifications()
     }
@@ -109,6 +116,8 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
         recordingFileID = nil
         completedSegmentURLs = []
         completedSegmentDuration = 0
+        terminalResult = nil
+        didSurfaceLowDiskWarning = false
         isRecording = false
         isPaused = false
         shouldResumeAfterInterruption = false
@@ -143,6 +152,9 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
     }
 
     private func startRecordingCore() throws {
+        didSurfaceLowDiskWarning = false
+        terminalResult = nil
+        try validateDiskSpaceBeforeStartingSegment(isInitialSegment: true)
         let session = AVAudioSession.sharedInstance()
 
         switch AVAudioApplication.shared.recordPermission {
@@ -185,6 +197,16 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
     }
 
     private func stopRecordingCore() throws -> RecordingResult {
+        if let terminalResult {
+            self.terminalResult = nil
+            completedSegmentURLs = []
+            completedSegmentDuration = 0
+            firstRecordingURL = nil
+            recordingFileID = nil
+            stopMetering()
+            finishAudioLevels()
+            return terminalResult
+        }
         guard let recorder, let firstRecordingURL, let recordingFileID else {
             throw RecordingError.noActiveRecording
         }
@@ -200,6 +222,8 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
         self.recordingFileID = nil
         self.completedSegmentURLs = []
         self.completedSegmentDuration = 0
+        self.terminalResult = nil
+        self.didSurfaceLowDiskWarning = false
         isRecording = false
         isPaused = false
         shouldResumeAfterInterruption = false
@@ -402,12 +426,15 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
         completedSegmentsDidChange?(completedSegmentURLs)
 
         do {
+            try validateDiskSpaceBeforeStartingSegment(isInitialSegment: false)
             let nextURL = try makeSegmentURL(id: UUID())
             let nextRecorder = try makeRecorder(at: nextURL)
             guard beginSegmentRecording(nextRecorder) else { throw RecordingError.recordingFailed() }
             self.recorder = nextRecorder
             self.recordingURL = nextURL
             DebugLogger.shared.addLog("AudioRecorder", "5分セグメントを確定し、次の録音セグメントを開始しました", level: .info)
+        } catch RecordingError.insufficientDiskSpace {
+            stopForInsufficientDiskSpace()
         } catch {
             self.recorder = nil
             self.recordingURL = nil
@@ -439,10 +466,47 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
         recorder.record(forDuration: max(0.01, Self.segmentDuration - recorder.currentTime))
     }
 
+    private func validateDiskSpaceBeforeStartingSegment(isInitialSegment: Bool) throws {
+        let audioDirectory = try STTFileLocations.audioDirectory()
+        let decision = diskSpaceGuard.decision(for: audioDirectory)
+        switch decision {
+        case .sufficient:
+            return
+        case .warning:
+            guard !didSurfaceLowDiskWarning else { return }
+            didSurfaceLowDiskWarning = true
+            diskSpaceDidChange?(.warning)
+            DebugLogger.shared.addLog("AudioRecorder", "録音保存先の空き容量が500 MB未満です。録音は継続します", level: .warning)
+        case .stop:
+            if !isInitialSegment {
+                DebugLogger.shared.addLog("AudioRecorder", "録音保存先の空き容量が200 MB未満です。新しいセグメントを開始しません", level: .error)
+            }
+            throw RecordingError.insufficientDiskSpace
+        }
+    }
+
+    private func stopForInsufficientDiskSpace() {
+        guard let firstRecordingURL, let recordingFileID else { return }
+        terminalResult = RecordingResult(
+            fileID: recordingFileID,
+            fileURL: firstRecordingURL,
+            segmentURLs: completedSegmentURLs,
+            duration: completedSegmentDuration
+        )
+        recorder = nil
+        recordingURL = nil
+        isRecording = false
+        isPaused = false
+        shouldResumeAfterInterruption = false
+        pauseMetering()
+        diskSpaceDidChange?(.stop)
+    }
+
     enum RecordingError: LocalizedError {
         case noActiveRecording
         case microphonePermissionDenied
         case audioSessionFailed(Error)
+        case insufficientDiskSpace
         case recordingFailed(Error? = nil)
 
         var errorDescription: String? {
@@ -453,6 +517,8 @@ final class AudioRecorder: NSObject, AudioRecorderProtocol {
                 return "マイクへのアクセスが許可されていません"
             case .audioSessionFailed(let error):
                 return "オーディオセッションの設定に失敗しました: \(error.localizedDescription)"
+            case .insufficientDiskSpace:
+                return "空き容量が不足しています。200 MB以上の空き容量を確保してから録音してください。"
             case .recordingFailed(let error):
                 if let error {
                     return "録音に失敗しました: \(error.localizedDescription)"

--- a/Memora/Core/Services/RecordingDiskSpaceGuard.swift
+++ b/Memora/Core/Services/RecordingDiskSpaceGuard.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Disk thresholds are expressed in bytes so every recording entry point uses
+/// the same policy. 500 MB warns early; 200 MB stops before a new five-minute
+/// AAC segment can be opened and corrupted by a full volume.
+enum RecordingDiskSpaceThresholds {
+    static let warningBytes: Int64 = 500 * 1024 * 1024
+    static let stopBytes: Int64 = 200 * 1024 * 1024
+}
+
+enum RecordingDiskSpaceDecision: Equatable {
+    case sufficient
+    case warning
+    case stop
+
+    var userMessage: String? {
+        switch self {
+        case .sufficient: nil
+        case .warning:
+            "空き容量が少なくなっています（500 MB未満）。録音を続けるには容量を確保してください。"
+        case .stop:
+            "空き容量が不足したため録音を安全に停止しました。確定済みの録音は保存されています。"
+        }
+    }
+}
+
+protocol RecordingDiskSpaceProviding {
+    func availableBytes(for volumeURL: URL) -> Int64?
+}
+
+struct SystemRecordingDiskSpaceProvider: RecordingDiskSpaceProviding {
+    func availableBytes(for volumeURL: URL) -> Int64? {
+        guard let values = try? volumeURL.resourceValues(forKeys: [
+            .volumeAvailableCapacityForImportantUsageKey,
+            .volumeAvailableCapacityKey
+        ]) else {
+            return nil
+        }
+        if let important = values.volumeAvailableCapacityForImportantUsage {
+            return important
+        }
+        return values.volumeAvailableCapacity.map(Int64.init)
+    }
+}
+
+struct RecordingDiskSpaceGuard {
+    let provider: any RecordingDiskSpaceProviding
+
+    init(provider: any RecordingDiskSpaceProviding = SystemRecordingDiskSpaceProvider()) {
+        self.provider = provider
+    }
+
+    func decision(for volumeURL: URL) -> RecordingDiskSpaceDecision {
+        guard let availableBytes = provider.availableBytes(for: volumeURL) else {
+            // A capacity lookup failure must not discard an otherwise valid
+            // recording. The recorder logs it and proceeds conservatively.
+            return .sufficient
+        }
+        if availableBytes < RecordingDiskSpaceThresholds.stopBytes { return .stop }
+        if availableBytes < RecordingDiskSpaceThresholds.warningBytes { return .warning }
+        return .sufficient
+    }
+}

--- a/Memora/Views/V6/V6RecordingView.swift
+++ b/Memora/Views/V6/V6RecordingView.swift
@@ -41,10 +41,17 @@ final class V6RecordingSessionController {
         activeProjectID = pendingProjectID
         pendingProjectID = nil
         errorMessage = nil
+        recordingViewModel.startRecording()
+        audioRecorder.diskSpaceDidChange = { [weak self] decision in
+            self?.handleDiskSpaceDecision(decision)
+        }
         do {
             try audioRecorder.startRecording()
         } catch {
-            errorMessage = "録音の開始に失敗しました。マイクへのアクセスを確認してください。"
+            recordingViewModel.stopRecording()
+            errorMessage = error.localizedDescription
+            recordingViewModel.errorMessage = error.localizedDescription
+            audioRecorder.diskSpaceDidChange = nil
             return
         }
         if let recordingURL = audioRecorder.primaryRecordingURL {
@@ -61,7 +68,6 @@ final class V6RecordingSessionController {
                 for: activeAudioFile
             )
         }
-        recordingViewModel.startRecording()
         isActive = true
         isPaused = false
         elapsed = 0
@@ -100,6 +106,7 @@ final class V6RecordingSessionController {
         defer {
             activeAudioFile = nil
             audioRecorder.completedSegmentsDidChange = nil
+            audioRecorder.diskSpaceDidChange = nil
         }
         if let activeAudioFile {
             return recordingViewModel.finishSegmentedRecording(result, title: title, for: activeAudioFile)
@@ -114,11 +121,43 @@ final class V6RecordingSessionController {
         recordingViewModel.discardSegmentedRecording(activeAudioFile)
         activeAudioFile = nil
         audioRecorder.completedSegmentsDidChange = nil
+        audioRecorder.diskSpaceDidChange = nil
         recordingViewModel.cancelRecording()
         isActive = false
         isPaused = false
         elapsed = 0
         highlightCount = 0
+    }
+
+    func dismissError() {
+        errorMessage = nil
+    }
+
+    private func handleDiskSpaceDecision(_ decision: RecordingDiskSpaceDecision) {
+        guard let message = decision.userMessage else { return }
+        errorMessage = message
+        recordingViewModel.errorMessage = message
+        guard decision == .stop else { return }
+
+        stopTimers()
+        recordingViewModel.stopRecording()
+        let result = try? audioRecorder.stopRecordingWithSegments()
+        let projectID = activeProjectID
+        isActive = false
+        isPaused = false
+        activeProjectID = nil
+        defer {
+            activeAudioFile = nil
+            audioRecorder.completedSegmentsDidChange = nil
+            audioRecorder.diskSpaceDidChange = nil
+        }
+        guard let result else { return }
+        let title = "録音 \(Self.diskStopTitleFormatter.string(from: .now))"
+        if let activeAudioFile {
+            _ = recordingViewModel.finishSegmentedRecording(result, title: title, for: activeAudioFile)
+        } else {
+            _ = recordingViewModel.saveRecording(title: title, fileURL: result.fileURL, duration: result.duration, projectID: projectID)
+        }
     }
 
     private func startTimers() {
@@ -153,6 +192,12 @@ final class V6RecordingSessionController {
         levelsTask?.cancel()
         levelsTask = nil
     }
+
+    private static let diskStopTitleFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy年MM月dd日 HH:mm"
+        return formatter
+    }()
 
     /// Formats elapsed time as `M:SS`, matching `.dc.html`'s `formatMMSS`.
     var elapsedLabel: String {
@@ -247,6 +292,17 @@ struct V6RecordingView: View {
             if !showDiscardConfirm {
                 island.enterLiveRecording()
             }
+        }
+        .alert(
+            "録音の状態",
+            isPresented: Binding(
+                get: { session.errorMessage != nil },
+                set: { if !$0 { session.dismissError() } }
+            )
+        ) {
+            Button("OK", role: .cancel) { session.dismissError() }
+        } message: {
+            Text(session.errorMessage ?? "")
         }
     }
 

--- a/MemoraTests/Services/RecordingDiskSpaceGuardTests.swift
+++ b/MemoraTests/Services/RecordingDiskSpaceGuardTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import Memora
+
+@Suite("録音ディスク残量ガード")
+struct RecordingDiskSpaceGuardTests {
+    private let volumeURL = URL(fileURLWithPath: "/tmp/memora-recording-volume")
+
+    @Test("停止閾値未満では録音開始を拒否する")
+    func rejectsStartBelowStopThreshold() {
+        let guarder = RecordingDiskSpaceGuard(
+            provider: FixedDiskSpaceProvider(bytes: RecordingDiskSpaceThresholds.stopBytes - 1)
+        )
+
+        #expect(guarder.decision(for: volumeURL) == .stop)
+    }
+
+    @Test("警告閾値未満かつ停止閾値以上では録音を継続する")
+    func warnsBetweenThresholds() {
+        let guarder = RecordingDiskSpaceGuard(
+            provider: FixedDiskSpaceProvider(bytes: RecordingDiskSpaceThresholds.warningBytes - 1)
+        )
+
+        #expect(guarder.decision(for: volumeURL) == .warning)
+    }
+
+    @Test("十分な空き容量では通常録音を許可する")
+    func allowsStartWithSufficientCapacity() {
+        let guarder = RecordingDiskSpaceGuard(
+            provider: FixedDiskSpaceProvider(bytes: RecordingDiskSpaceThresholds.warningBytes)
+        )
+
+        #expect(guarder.decision(for: volumeURL) == .sufficient)
+    }
+}
+
+private struct FixedDiskSpaceProvider: RecordingDiskSpaceProviding {
+    let bytes: Int64?
+    func availableBytes(for volumeURL: URL) -> Int64? { bytes }
+}


### PR DESCRIPTION
## 概要
- P0-2(c): 録音保存先の空き容量を監視し、500 MiB未満で一度だけ警告、200 MiB未満で次のセグメントを開始せず安全に停止します。
- `volumeAvailableCapacityForImportantUsageKey` を優先し、取得できない場合は `volumeAvailableCapacityKey` にフォールバックします。
- 既存の確定済みセグメント通知後に判定するため、停止時も確定済みセグメントをSwiftDataへ保存します。

## 検証
- `swift test --package-path Packages/MemoraSharedData`（27 tests / 7 suites）
- `xcodebuild -project Memora.xcodeproj -scheme Memora -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`\n- 閾値判定のDI単体テスト（開始拒否・警告・停止）\n\n## 手動確認\n- Simulatorで容量枯渇を安全に再現できないため未実施。実機で要確認。\n\n## 影響範囲\n- Schema変更なし、STTコア保護ファイルは未変更。通常容量では既存の録音・セグメント保存経路を維持します。