### PR TITLE
fix: restore V3 SwiftData migration compatibility

### DIFF
--- a/Packages/MemoraSharedData/Sources/MemoraSharedSchema/MemoraSchema.swift
+++ b/Packages/MemoraSharedData/Sources/MemoraSharedSchema/MemoraSchema.swift
@@ -93,6 +93,186 @@ public enum MemoraSchemaV3: VersionedSchema {
         BotMeetingConfig.self,
         ScheduledBotMeeting.self
     ]
+
+    /// V3 リリース時の `AudioFile` 関係グラフの固定スナップショット。
+    /// `segmentPaths` は V4 で初めて追加されたため、ここには含めない。
+    @Model
+    public final class AudioFile {
+        public var id: UUID
+        public var title: String
+        public var createdAt: Date
+        public var duration: TimeInterval
+        public var audioURL: String
+        public var isTranscribed: Bool = false
+        public var projectID: UUID?
+        public var isSummarized: Bool = false
+        public var summary: String?
+        public var keyPoints: String?
+        public var actionItems: String?
+        public var isLifeLog: Bool = false
+        public var lifeLogTags: [String] = []
+        public var calendarEventId: String?
+        public var sourceTypeRaw: String = SourceType.recording.rawValue
+        public var referenceTranscript: String?
+        public var referenceSpeakerCount: Int?
+
+        @Relationship(deleteRule: .cascade, inverse: \Transcript.audioFile)
+        public var transcripts: [Transcript] = []
+        @Relationship(deleteRule: .cascade, inverse: \ProcessingJob.audioFile)
+        public var processingJobs: [ProcessingJob] = []
+        @Relationship(deleteRule: .cascade, inverse: \PhotoAttachment.audioFile)
+        public var photoAttachments: [PhotoAttachment] = []
+        @Relationship(deleteRule: .cascade, inverse: \KnowledgeChunk.audioFile)
+        public var knowledgeChunks: [KnowledgeChunk] = []
+        @Relationship(deleteRule: .cascade, inverse: \CalendarEventLink.audioFile)
+        public var calendarEventLinks: [CalendarEventLink] = []
+
+        public init(title: String, audioURL: String, projectID: UUID? = nil) {
+            self.id = UUID()
+            self.title = title
+            self.createdAt = Date()
+            self.duration = 0
+            self.audioURL = audioURL
+            self.projectID = projectID
+        }
+    }
+
+    @Model
+    public final class Transcript {
+        public var id: UUID
+        public var audioFileID: UUID
+        public var audioFile: AudioFile?
+        public var text: String
+        public var createdAt: Date
+        public var speakerLabels: [String] = []
+        public var segmentStartTimes: [Double] = []
+        public var segmentEndTimes: [Double] = []
+        public var segmentTexts: [String] = []
+
+        public init(audioFileID: UUID, text: String) {
+            self.id = UUID()
+            self.audioFileID = audioFileID
+            self.audioFile = nil
+            self.text = text
+            self.createdAt = Date()
+        }
+    }
+
+    @Model
+    public final class ProcessingJob {
+        public var id: UUID
+        public var audioFileID: UUID
+        public var audioFile: AudioFile?
+        public var jobType: String
+        public var status: String
+        public var progress: Double = 0
+        public var error: String?
+        public var startedAt: Date?
+        public var completedAt: Date?
+        public var stage: String
+        public var retryCount: Int = 0
+        public var maxRetries: Int = 1
+        public var createdAt: Date
+
+        public init(audioFileID: UUID, jobType: String) {
+            self.id = UUID()
+            self.audioFileID = audioFileID
+            self.audioFile = nil
+            self.jobType = jobType
+            self.status = "pending"
+            self.stage = "none"
+            self.createdAt = Date()
+        }
+    }
+
+    @Model
+    public final class PhotoAttachment {
+        public var id: UUID
+        public var ownerTypeRaw: String
+        public var ownerID: UUID
+        public var audioFile: AudioFile?
+        public var sortOrder: Int
+        public var localPath: String
+        public var thumbnailPath: String?
+        public var caption: String?
+        public var ocrText: String?
+        public var createdAt: Date
+        public var updatedAt: Date
+
+        public init(id: UUID = UUID(), ownerType: PhotoAttachmentOwnerType, ownerID: UUID, sortOrder: Int = 0, localPath: String, thumbnailPath: String? = nil, caption: String? = nil, ocrText: String? = nil, createdAt: Date = Date(), updatedAt: Date = Date()) {
+            self.id = id
+            self.ownerTypeRaw = ownerType.rawValue
+            self.ownerID = ownerID
+            self.audioFile = nil
+            self.sortOrder = sortOrder
+            self.localPath = localPath
+            self.thumbnailPath = thumbnailPath
+            self.caption = caption
+            self.ocrText = ocrText
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+        }
+    }
+
+    @Model
+    public final class KnowledgeChunk {
+        public var id: UUID
+        public var scopeTypeRaw: String
+        public var scopeID: UUID?
+        public var sourceTypeRaw: String
+        public var sourceID: UUID?
+        public var audioFile: AudioFile?
+        public var text: String
+        public var keywords: [String]
+        public var rankHint: Double
+        public var createdAt: Date
+        public var updatedAt: Date
+
+        public init(id: UUID = UUID(), scopeType: KnowledgeChunkScopeType, scopeID: UUID? = nil, sourceType: KnowledgeChunkSourceType, sourceID: UUID? = nil, text: String, keywords: [String] = [], rankHint: Double = 0, createdAt: Date = Date(), updatedAt: Date = Date()) {
+            self.id = id
+            self.scopeTypeRaw = scopeType.rawValue
+            self.scopeID = scopeID
+            self.sourceTypeRaw = sourceType.rawValue
+            self.sourceID = sourceID
+            self.audioFile = nil
+            self.text = text
+            self.keywords = keywords
+            self.rankHint = rankHint
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+        }
+    }
+
+    @Model
+    public final class CalendarEventLink {
+        public var id: UUID
+        public var provider: String
+        public var externalID: String
+        public var audioFile: AudioFile?
+        public var title: String
+        public var startAt: Date
+        public var endAt: Date
+        public var meetingURL: String?
+        public var conferenceProvider: String?
+        public var audioFileID: UUID?
+        public var createdAt: Date
+        public var updatedAt: Date
+
+        public init(id: UUID = UUID(), provider: String, externalID: String, title: String, startAt: Date, endAt: Date, meetingURL: String? = nil, conferenceProvider: String? = nil, audioFileID: UUID? = nil) {
+            self.id = id
+            self.provider = provider
+            self.externalID = externalID
+            self.audioFile = nil
+            self.title = title
+            self.startAt = startAt
+            self.endAt = endAt
+            self.meetingURL = meetingURL
+            self.conferenceProvider = conferenceProvider
+            self.audioFileID = audioFileID
+            self.createdAt = Date()
+            self.updatedAt = Date()
+        }
+    }
 }
 
 // MARK: - Schema V4
@@ -102,7 +282,30 @@ public enum MemoraSchemaV3: VersionedSchema {
 public enum MemoraSchemaV4: VersionedSchema {
     public static var versionIdentifier = Schema.Version(4, 0, 0)
 
-    public static let models: [any PersistentModel.Type] = MemoraSchemaV3.models
+    public static let models: [any PersistentModel.Type] = [
+        AudioFile.self,
+        Transcript.self,
+        Project.self,
+        MeetingNote.self,
+        MeetingMemo.self,
+        PhotoAttachment.self,
+        KnowledgeChunk.self,
+        AskAISession.self,
+        AskAIMessage.self,
+        MemoryProfile.self,
+        MemoryFact.self,
+        TodoItem.self,
+        ProcessingJob.self,
+        WebhookSettings.self,
+        PlaudSettings.self,
+        CalendarEventLink.self,
+        GoogleMeetSettings.self,
+        NotionSettings.self,
+        CustomSummaryTemplate.self,
+        OnlineMeetingCapture.self,
+        BotMeetingConfig.self,
+        ScheduledBotMeeting.self
+    ]
 }
 
 // MARK: - Migration Plan

--- a/Packages/MemoraSharedData/Tests/MemoraSharedDataTests/MemoraSharedDataTests.swift
+++ b/Packages/MemoraSharedData/Tests/MemoraSharedDataTests/MemoraSharedDataTests.swift
@@ -163,6 +163,38 @@ struct MemoraSharedDataTests {
     #expect(v3 != v4)
   }
 
+  @Test("V3 AudioFile migrates through the shared store factory")
+  func v3AudioFileMigratesThroughSharedStoreFactory() throws {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("memora-v3-v4-\(UUID().uuidString)", isDirectory: true)
+    let storeURL = root.appendingPathComponent("Memora.store")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let legacyID = UUID()
+    do {
+      let container = try ModelContainer(
+        for: Schema(versionedSchema: MemoraSchemaV3.self),
+        configurations: ModelConfiguration(url: storeURL, allowsSave: true, cloudKitDatabase: .none)
+      )
+      let context = ModelContext(container)
+      let legacy = MemoraSchemaV3.AudioFile(
+        title: "V3 recording",
+        audioURL: "/tmp/legacy.m4a"
+      )
+      legacy.id = legacyID
+      context.insert(legacy)
+      try context.save()
+    }
+
+    let migrated = try MemoraSharedStoreFactory.makePersistentContainer(at: storeURL)
+    let files = try ModelContext(migrated).fetch(FetchDescriptor<AudioFile>())
+    let file = try #require(files.first(where: { $0.id == legacyID }))
+    #expect(file.title == "V3 recording")
+    #expect(file.audioURL == "/tmp/legacy.m4a")
+    #expect(file.segmentPaths.isEmpty)
+  }
+
   @Test("in-memory store supports page, update, and delete")
   func inMemoryStoreCRUD() throws {
     let first = MemoraSharedAudioFileRecord(

--- a/Packages/MemoraSharedData/Tests/MemoraSharedDataTests/MemoraSharedDataTests.swift
+++ b/Packages/MemoraSharedData/Tests/MemoraSharedDataTests/MemoraSharedDataTests.swift
@@ -155,32 +155,12 @@ struct MemoraSharedDataTests {
     #expect(decoded.segmentPaths.count == 2)
   }
 
-  @Test("V3 store migrates to V4 with legacy single-path audio intact")
-  func v3StoreMigratesToV4WithEmptySegmentPaths() throws {
-    let root = FileManager.default.temporaryDirectory
-      .appendingPathComponent("memora-v3-v4-\(UUID().uuidString)", isDirectory: true)
-    let storeURL = root.appendingPathComponent("Memora.store")
-    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-    defer { try? FileManager.default.removeItem(at: root) }
+  @Test("V3 and V4 have distinct schema checksums")
+  func v3AndV4SchemasAreDistinct() {
+    let v3 = Schema(versionedSchema: MemoraSchemaV3.self)
+    let v4 = Schema(versionedSchema: MemoraSchemaV4.self)
 
-    do {
-      let v3 = try ModelContainer(
-        for: Schema(versionedSchema: MemoraSchemaV3.self),
-        configurations: ModelConfiguration(url: storeURL, allowsSave: true, cloudKitDatabase: .none)
-      )
-      let context = ModelContext(v3)
-      context.insert(AudioFile(title: "V3 recording", audioURL: "/tmp/legacy.m4a"))
-      try context.save()
-    }
-
-    let v4 = try ModelContainer(
-      for: Schema(versionedSchema: MemoraSchemaV4.self),
-      migrationPlan: MemoraMigrationPlan.self,
-      configurations: ModelConfiguration(url: storeURL, allowsSave: true, cloudKitDatabase: .none)
-    )
-    let migrated = try #require(try ModelContext(v4).fetch(FetchDescriptor<AudioFile>()).first)
-    #expect(migrated.audioURL == "/tmp/legacy.m4a")
-    #expect(migrated.segmentPaths.isEmpty)
+    #expect(v3 != v4)
   }
 
   @Test("in-memory store supports page, update, and delete")
@@ -220,7 +200,7 @@ struct MemoraSharedSchemaRepositoryTests {
   func audioFileRepositoryCRUD() throws {
     let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
     let container = try ModelContainer(
-      for: Schema(versionedSchema: MemoraSchemaV3.self),
+      for: Schema(versionedSchema: MemoraSchemaV4.self),
       configurations: configuration
     )
     let repository = AudioFileRepository(modelContext: ModelContext(container))


### PR DESCRIPTION
## 概要

V4で現行の`AudioFile`をV3の履歴スキーマにも再利用していたため、V3/V4のチェックサムが重複し、既存ストアの起動時にクラッシュしていました。

- V3の`AudioFile`関係グラフを履歴スナップショットとして固定
- V4は`segmentPaths`を含む現行モデル群を明示
- V3/V4チェックサムが異なることを回帰テスト化
- 現行モデルを使うin-memory repositoryテストをV4へ更新

## 実ストア検証

- Jul 14作成のV3世代App Groupストアは元ファイルを変更せずコピーして検証
- 加えて、V4以前のコミットで実生成したV3ストア（`AudioFile` 1件）をV4へ軽量移行し、タイトルと空の`segmentPaths`を確認

## 検証

- `swift test --package-path Packages/MemoraSharedData`
- `xcodebuild -project Memora.xcodeproj -scheme Memora -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- `cd apps/mobile-expo && npm run qa:ios:build`

## §8

STT保護ファイルは変更していません。