### PR TITLE
fix: 空の実ストアでモック録音を表示しない

### DIFF
--- a/apps/mobile-expo/src/native/MemoraNative.ts
+++ b/apps/mobile-expo/src/native/MemoraNative.ts
@@ -249,7 +249,9 @@ export const MemoraNative: MemoraNativeModule = {
       nativeModule.listAudioFiles?.(),
     );
 
-    if (nativeFiles?.length) {
+    // An empty array is a valid response from a connected SwiftData store.
+    // Only use fixture data when the native module itself is unavailable.
+    if (nativeFiles) {
       return nativeFiles;
     }
 


### PR DESCRIPTION
Closes #138

実ストアのネイティブブリッジが返す空配列を有効な応答として返すよう修正しました。モジュール未接続時だけ既存のモックフォールバックを使用します。

検証: typecheck / Web export pass。外部DerivedDataでRN iOSビルド実行中。