### PR TITLE
feat: RN画面をFigmaデザイントークンに統一

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "expo-web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "apps/mobile-expo", "run", "web", "--", "--port", "8081"],
+      "port": 8081
+    }
+  ]
+}

--- a/apps/mobile-expo/app/_layout.tsx
+++ b/apps/mobile-expo/app/_layout.tsx
@@ -2,10 +2,29 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import {
+  useFonts,
+  IBMPlexSansJP_200ExtraLight,
+  IBMPlexSansJP_300Light,
+  IBMPlexSansJP_400Regular,
+  IBMPlexSansJP_500Medium,
+  IBMPlexSansJP_600SemiBold,
+} from '@expo-google-fonts/ibm-plex-sans-jp';
 import { colors } from '../src/design/tokens';
 import { CaptureFlowProvider } from '../src/features/capture/CaptureFlowProvider';
 
 export default function RootLayout() {
+  const [fontsLoaded] = useFonts({
+    IBMPlexSansJP_200ExtraLight,
+    IBMPlexSansJP_300Light,
+    IBMPlexSansJP_400Regular,
+    IBMPlexSansJP_500Medium,
+    IBMPlexSansJP_600SemiBold,
+  });
+
+  // フォント確定までは描画しない（Figma の IBM Plex とのズレ防止）
+  if (!fontsLoaded) return null;
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <BottomSheetModalProvider>

--- a/apps/mobile-expo/src/components/DateSeparator.tsx
+++ b/apps/mobile-expo/src/components/DateSeparator.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, Text, View } from 'react-native';
-import { colors, spacing } from '../design/tokens';
+import { colors, spacing, textStyles } from '../design/tokens';
 
 type DateSeparatorProps = {
   date: string;
@@ -29,7 +29,6 @@ const dsStyles = StyleSheet.create({
   },
   label: {
     color: colors.textTertiary,
-    fontSize: 12,
-    fontWeight: '500',
+    ...textStyles.caption,
   },
 });

--- a/apps/mobile-expo/src/components/FileCard.tsx
+++ b/apps/mobile-expo/src/components/FileCard.tsx
@@ -1,7 +1,7 @@
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { AppIcon } from './AppIcon';
 import { StatusPill } from './StatusPill';
-import { colors, radius, spacing, shadow } from '../design/tokens';
+import { colors, radius, spacing, shadow, textStyles } from '../design/tokens';
 import type { AudioFile } from '../types/memora';
 import { formatRecordedAt } from '../utils/formatRecordedAt';
 
@@ -40,7 +40,7 @@ export function FileCard({
         <Text numberOfLines={1} style={fcStyles.title}>
           {file.title}
         </Text>
-        <Text style={fcStyles.meta}>
+        <Text numberOfLines={1} style={fcStyles.meta}>
           {formatRecordedAt(file.recordedAt)} · {file.duration}
         </Text>
         {showSummary && file.summary ? (
@@ -102,18 +102,17 @@ const fcStyles = StyleSheet.create({
   },
   title: {
     color: colors.text,
-    fontSize: 15,
-    fontWeight: '700',
+    ...textStyles.bodyBold,
   },
   meta: {
     color: colors.textSecondary,
-    fontSize: 11,
     marginTop: 1,
+    ...textStyles.caption,
   },
   summary: {
     color: colors.textSecondary,
-    fontSize: 13,
     marginTop: 4,
+    ...textStyles.footnote,
   },
   more: {
     alignItems: 'center',

--- a/apps/mobile-expo/src/components/OfflineBanner.tsx
+++ b/apps/mobile-expo/src/components/OfflineBanner.tsx
@@ -1,6 +1,6 @@
 import { StyleSheet, Text, View } from 'react-native';
 import { AppIcon } from './AppIcon';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 
 type OfflineBannerProps = {
   message?: string;
@@ -30,7 +30,6 @@ const obStyles = StyleSheet.create({
   text: {
     color: colors.text,
     flex: 1,
-    fontSize: 13,
-    fontWeight: '500',
+    ...textStyles.footnoteBold,
   },
 });

--- a/apps/mobile-expo/src/components/PlayerBar.tsx
+++ b/apps/mobile-expo/src/components/PlayerBar.tsx
@@ -1,7 +1,7 @@
 import { AppIcon } from './AppIcon';
 import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View, type LayoutChangeEvent, type GestureResponderEvent } from 'react-native';
-import { colors } from '../design/tokens';
+import { colors, textStyles } from '../design/tokens';
 import type { PlaybackStatusDTO } from '../native/MemoraNative.types';
 
 type Props = {
@@ -79,9 +79,8 @@ const styles = StyleSheet.create({
   },
   time: {
     color: colors.text,
-    fontSize: 13,
     fontVariant: ['tabular-nums'],
-    fontWeight: '500',
+    ...textStyles.footnote,
   },
   spacer: { flex: 1 },
   rateButton: {
@@ -92,8 +91,7 @@ const styles = StyleSheet.create({
   },
   rateText: {
     color: colors.text,
-    fontSize: 11.5,
-    fontWeight: '600',
+    ...textStyles.captionBold,
   },
   pressed: { opacity: 0.74, transform: [{ scale: 0.93 }] },
   trackWrap: {

--- a/apps/mobile-expo/src/components/Screen.tsx
+++ b/apps/mobile-expo/src/components/Screen.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react';
 import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View, type RefreshControlProps } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { colors, spacing } from '../design/tokens';
+import { colors, spacing, textStyles } from '../design/tokens';
 
 type Props = {
   title?: string;
@@ -82,19 +82,13 @@ const styles = StyleSheet.create({
   title: {
     color: colors.text,
     flex: 1,
-    fontSize: 30,
-    fontWeight: '700',
-    letterSpacing: -0.6,
-    lineHeight: 36,
+    ...textStyles.screenTitle,
   },
   homeTitle: {
-    fontSize: 32,
-    letterSpacing: -0.64,
-    lineHeight: 38,
+    ...textStyles.screenTitle,
   },
   subtitle: {
     color: colors.textSecondary,
-    fontSize: 15,
-    lineHeight: 22,
+    ...textStyles.body,
   },
 });

--- a/apps/mobile-expo/src/components/SearchBar.tsx
+++ b/apps/mobile-expo/src/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import { Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { AppIcon } from './AppIcon';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 
 type SearchBarProps = {
   value: string;
@@ -65,9 +65,9 @@ const searchBarStyles = StyleSheet.create({
   input: {
     color: colors.text,
     flex: 1,
-    fontSize: 15,
     minHeight: 44,
     paddingVertical: spacing.xs,
+    ...textStyles.body,
   },
   clearButton: {
     alignItems: 'center',

--- a/apps/mobile-expo/src/components/Section.tsx
+++ b/apps/mobile-expo/src/components/Section.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { colors, spacing } from '../design/tokens';
+import { colors, spacing, textStyles } from '../design/tokens';
 
 type Props = {
   title: string;
@@ -31,8 +31,7 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.text,
-    fontSize: 12,
-    fontWeight: '500',
+    ...textStyles.captionBold,
     letterSpacing: 0,
     textTransform: 'uppercase',
   },

--- a/apps/mobile-expo/src/components/SegmentedControl.tsx
+++ b/apps/mobile-expo/src/components/SegmentedControl.tsx
@@ -1,5 +1,5 @@
 import { LayoutAnimation, Pressable, StyleSheet, Text, View } from 'react-native';
-import { colors, radius, spacing, shadow } from '../design/tokens';
+import { colors, radius, spacing, shadow, textStyles } from '../design/tokens';
 
 type SegmentedControlProps<T extends string> = {
   segments: Array<{ key: T; label: string }>;
@@ -60,8 +60,7 @@ const segStyles = StyleSheet.create({
   },
   label: {
     color: colors.textSecondary,
-    fontSize: 13,
-    fontWeight: '600',
+    ...textStyles.footnoteBold,
   },
   labelActive: {
     color: colors.text,

--- a/apps/mobile-expo/src/components/StateViews.tsx
+++ b/apps/mobile-expo/src/components/StateViews.tsx
@@ -1,6 +1,6 @@
 import { AppIcon } from './AppIcon';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 
 export function LoadingState({ label = '読み込み中' }: { label?: string }) {
   return (
@@ -88,19 +88,17 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.text,
-    fontSize: 18,
-    fontWeight: '700',
     marginTop: spacing.sm,
+    ...textStyles.callout,
   },
   body: {
     color: colors.textSecondary,
-    fontSize: 14,
-    lineHeight: 21,
     textAlign: 'center',
+    ...textStyles.footnote,
   },
   retryButton: { alignItems: 'center', backgroundColor: colors.text, borderRadius: radius.md, marginTop: spacing.sm, minWidth: 112, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
   retryButtonPressed: { opacity: 0.78, transform: [{ scale: 0.98 }] },
-  retryButtonText: { color: colors.surface, fontSize: 14, fontWeight: '600' },
+  retryButtonText: { color: colors.surface, ...textStyles.footnoteBold },
   ctaButton: { alignItems: 'center', backgroundColor: colors.accent, borderRadius: radius.md, marginTop: spacing.md, minWidth: 160, paddingHorizontal: spacing.lg, paddingVertical: spacing.md },
-  ctaButtonText: { color: colors.surface, fontSize: 14, fontWeight: '600' },
+  ctaButtonText: { color: colors.surface, ...textStyles.footnoteBold },
 });

--- a/apps/mobile-expo/src/components/StatusPill.tsx
+++ b/apps/mobile-expo/src/components/StatusPill.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, Text, View } from 'react-native';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 import type { AudioStatus } from '../types/memora';
 
 const statusCopy: Record<AudioStatus, string> = {
@@ -39,7 +39,6 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
   },
   label: {
-    fontSize: 12,
-    fontWeight: '600',
+    ...textStyles.captionBold,
   },
 });

--- a/apps/mobile-expo/src/components/TranscriptionProgressCard.tsx
+++ b/apps/mobile-expo/src/components/TranscriptionProgressCard.tsx
@@ -1,6 +1,6 @@
 import { AppIcon } from './AppIcon';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 import type {
   TranscriptionEventDTO,
   TranscriptionTaskDTO,
@@ -93,13 +93,11 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.text,
-    fontSize: 16,
-    fontWeight: '700',
+    ...textStyles.callout,
   },
   subtitle: {
     color: colors.textSecondary,
-    fontSize: 13,
-    lineHeight: 19,
+    ...textStyles.footnote,
   },
   progressTrack: {
     backgroundColor: colors.surfaceAlt,
@@ -114,14 +112,12 @@ const styles = StyleSheet.create({
   },
   progressText: {
     color: colors.textSecondary,
-    fontSize: 12,
-    fontWeight: '700',
     textAlign: 'right',
+    ...textStyles.captionBold,
   },
   errorText: {
     color: colors.danger,
-    fontSize: 13,
-    fontWeight: '600',
+    ...textStyles.footnoteBold,
   },
   actions: {
     flexDirection: 'row',
@@ -139,7 +135,7 @@ const styles = StyleSheet.create({
   },
   primaryText: {
     color: colors.surface,
-    fontWeight: '700',
+    ...textStyles.bodyBold,
   },
   secondaryButton: {
     alignItems: 'center',
@@ -150,7 +146,7 @@ const styles = StyleSheet.create({
   },
   secondaryText: {
     color: colors.accent,
-    fontWeight: '700',
+    ...textStyles.bodyBold,
   },
   disabledText: {
     color: colors.textTertiary,

--- a/apps/mobile-expo/src/design/tokens.ts
+++ b/apps/mobile-expo/src/design/tokens.ts
@@ -7,16 +7,20 @@
 import type { LayoutAnimationConfig } from 'react-native';
 
 // ── Fonts ──────────────────────────────────────────────────
+// Figma: IBM Plex Sans JP（本文=ExtraLight / 強調=Light）。
+// fontFamily がウェイトを内包するため fontWeight は Android フォールバック用。
 export const fonts = {
   sans: {
-    regular:  { fontFamily: 'NotoSansJP_400Regular', fontWeight: '400' as const },
-    medium:   { fontFamily: 'NotoSansJP_500Medium',  fontWeight: '500' as const },
-    bold:     { fontFamily: 'NotoSansJP_700Bold',     fontWeight: '700' as const },
+    extralight: { fontFamily: 'IBMPlexSansJP_200ExtraLight', fontWeight: '200' as const },
+    light:      { fontFamily: 'IBMPlexSansJP_300Light',      fontWeight: '300' as const },
+    regular:    { fontFamily: 'IBMPlexSansJP_400Regular',    fontWeight: '400' as const },
+    medium:     { fontFamily: 'IBMPlexSansJP_500Medium',     fontWeight: '500' as const },
+    semibold:   { fontFamily: 'IBMPlexSansJP_600SemiBold',   fontWeight: '600' as const },
   },
+  // display も IBM Plex に統一（旧 M PLUS 1p は廃止）
   display: {
-    regular:  { fontFamily: 'MPLUS1p_400Regular', fontWeight: '400' as const },
-    medium:   { fontFamily: 'MPLUS1p_500Medium',  fontWeight: '500' as const },
-    bold:     { fontFamily: 'MPLUS1p_700Bold',     fontWeight: '700' as const },
+    extralight: { fontFamily: 'IBMPlexSansJP_200ExtraLight', fontWeight: '200' as const },
+    light:      { fontFamily: 'IBMPlexSansJP_300Light',      fontWeight: '300' as const },
   },
   mono: {
     regular:  { fontFamily: 'Menlo', fontWeight: '400' as const },
@@ -26,35 +30,35 @@ export const fonts = {
 
 // ── Colors (Light) ─────────────────────────────────────────
 export const colors = {
-  canvas:         '#FAFAF8',
+  canvas:         '#F7F7F6',
   surface:        '#FFFFFF',
-  surfaceAlt:     '#F3F3F2',
+  surfaceAlt:     '#F1F1F0',
   surfaceElevated:'#FFFFFF',
 
-  text:           '#1A1C1E',
-  textSecondary:  '#5F6368',
-  textTertiary:   '#9AA0A6',
+  text:           '#16171A',
+  textSecondary:  '#6B6D70',
+  textTertiary:   '#A0A2A5',
   textInverse:    '#FFFFFF',
 
-  border:         '#E2E3E5',
-  borderLight:    '#EEEEEF',
-  separator:      '#F0F0F0',
+  border:         '#E4E4E3',
+  borderLight:    '#EDEDEC',
+  separator:      '#EFEFEE',
 
-  accent:         '#1A7F6B',
-  accentSoft:     '#E8F5F1',
-  accentMuted:    '#B8D8CF',
+  accent:         '#5B6B7A',
+  accentSoft:     '#EEF0F2',
+  accentMuted:    '#C4CAD1',
 
-  success:        '#2E7D32',
-  successSoft:    '#E8F5E9',
-  warning:        '#E65100',
-  warningSoft:    '#FFF3E0',
-  danger:         '#C62828',
-  dangerSoft:     '#FFEBEE',
-  info:           '#1565C0',
-  infoSoft:       '#E3F2FD',
+  success:        '#4F7A55',
+  successSoft:    '#EDF2ED',
+  warning:        '#8A6A3C',
+  warningSoft:    '#F5EFE7',
+  danger:         '#A34B45',
+  dangerSoft:     '#F6ECEB',
+  info:           '#46647D',
+  infoSoft:       '#ECF0F3',
 
-  recording:      '#C62828',
-  recordingSoft:  '#FFEBEE',
+  recording:      '#A34B45',
+  recordingSoft:  '#F6ECEB',
 
   skeleton:       '#E8E8E6',
   skeletonShimmer:'#F0F0EE',
@@ -62,45 +66,57 @@ export const colors = {
   overlay:        'rgba(0,0,0,0.40)',
   overlayLight:   'rgba(0,0,0,0.20)',
 
+  // Category（アプリアイコン由来・タグ/アバター用）
+  categorySlate:  '#5B6B7A',
+  categoryTeal:   '#4E7D78',
+  categoryOlive:  '#6B7052',
+  categoryMauve:  '#766A80',
+
 } as const;
 
 // ── Colors (Dark) ──────────────────────────────────────────
 export const darkColors = {
-  canvas:         '#0F1114',
-  surface:        '#1A1D21',
-  surfaceAlt:     '#23262A',
-  surfaceElevated:'#2A2D32',
+  canvas:         '#101112',
+  surface:        '#17181A',
+  surfaceAlt:     '#202123',
+  surfaceElevated:'#26272A',
 
-  text:           '#E8EAED',
-  textSecondary:  '#9AA0A6',
-  textTertiary:   '#5F6368',
-  textInverse:    '#1A1C1E',
+  text:           '#E9E9E8',
+  textSecondary:  '#9C9D9F',
+  textTertiary:   '#616264',
+  textInverse:    '#16171A',
 
-  border:         '#3C4043',
-  borderLight:    '#313437',
-  separator:      '#2A2D32',
+  border:         '#313234',
+  borderLight:    '#2A2B2D',
+  separator:      '#26272A',
 
-  accent:         '#3DD9B0',
-  accentSoft:     '#1A332E',
-  accentMuted:    '#2A5C52',
+  accent:         '#9AA7B3',
+  accentSoft:     '#23272B',
+  accentMuted:    '#3D444B',
 
-  success:        '#4CAF50',
-  successSoft:    '#1B3320',
-  warning:        '#FF9800',
-  warningSoft:    '#332A1A',
-  danger:         '#EF5350',
-  dangerSoft:     '#331A1D',
-  info:           '#42A5F5',
-  infoSoft:       '#1A2533',
+  success:        '#7FA187',
+  successSoft:    '#1E2A20',
+  warning:        '#B99A6C',
+  warningSoft:    '#2B2620',
+  danger:         '#C98884',
+  dangerSoft:     '#2E2120',
+  info:           '#7C9AB0',
+  infoSoft:       '#1E262C',
 
-  recording:      '#EF5350',
-  recordingSoft:  '#331A1D',
+  recording:      '#C98884',
+  recordingSoft:  '#2E2120',
 
   skeleton:       '#23262A',
   skeletonShimmer:'#2A2D32',
 
   overlay:        'rgba(0,0,0,0.60)',
   overlayLight:   'rgba(0,0,0,0.35)',
+
+  // Category（アプリアイコン由来・タグ/アバター用）
+  categorySlate:  '#8A97A3',
+  categoryTeal:   '#7FA69F',
+  categoryOlive:  '#9AA07E',
+  categoryMauve:  '#A99DB2',
 } as const;
 
 // ── Spacing (golden ratio) ─────────────────────────────────
@@ -149,44 +165,71 @@ export const typography = {
 } as const;
 
 // ── Text style presets ─────────────────────────────────────
+// Figma「02 Components → Text styles」と 1:1 対応（サイズ/行間は Figma 実値）。
 export const textStyles = {
-  screenTitle: {
-    fontSize: typography.size.title1,
-    lineHeight: typography.lineHeight(30, 1.3),
+  display: {
+    fontSize: 36,
+    lineHeight: 41,
     letterSpacing: typography.letterSpacing.tight,
-    ...fonts.sans.bold,
+    ...fonts.display.extralight,
+  },
+  screenTitle: {
+    fontSize: 30,
+    lineHeight: 39,
+    letterSpacing: typography.letterSpacing.tight,
+    ...fonts.sans.extralight,
+  },
+  title2: {
+    fontSize: 24,
+    lineHeight: 34,
+    ...fonts.sans.extralight,
   },
   sectionTitle: {
-    fontSize: typography.size.title3,
-    lineHeight: typography.lineHeight(20, 1.4),
-    ...fonts.sans.bold,
+    fontSize: 20,
+    lineHeight: 28,
+    ...fonts.sans.extralight,
+  },
+  callout: {
+    fontSize: 17,
+    lineHeight: 26,
+    ...fonts.sans.extralight,
   },
   body: {
-    fontSize: typography.size.body,
-    lineHeight: typography.lineHeight(15, 1.6),
-    ...fonts.sans.regular,
+    fontSize: 15,
+    lineHeight: 24,
+    ...fonts.sans.extralight,
   },
   bodyBold: {
-    fontSize: typography.size.body,
-    lineHeight: typography.lineHeight(15, 1.6),
-    ...fonts.sans.bold,
+    fontSize: 15,
+    lineHeight: 24,
+    ...fonts.sans.light,
+  },
+  footnote: {
+    fontSize: 13,
+    lineHeight: 20,
+    ...fonts.sans.extralight,
+  },
+  footnoteBold: {
+    fontSize: 13,
+    lineHeight: 20,
+    ...fonts.sans.light,
   },
   caption: {
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight(11, 1.4),
+    fontSize: 11,
+    lineHeight: 15,
     letterSpacing: typography.letterSpacing.wide,
-    ...fonts.sans.regular,
+    ...fonts.sans.light,
+  },
+  captionBold: {
+    fontSize: 11,
+    lineHeight: 15,
+    letterSpacing: typography.letterSpacing.wide,
+    ...fonts.sans.light,
   },
   monoBody: {
     fontSize: 13,
-    lineHeight: typography.lineHeight(13, 1.5),
+    lineHeight: 20,
     ...fonts.mono.regular,
-  },
-  display: {
-    fontSize: typography.size.headline,
-    lineHeight: typography.lineHeight(36, 1.15),
-    letterSpacing: typography.letterSpacing.tight,
-    ...fonts.display.bold,
   },
 };
 

--- a/apps/mobile-expo/src/features/capture/CaptureFlowProvider.tsx
+++ b/apps/mobile-expo/src/features/capture/CaptureFlowProvider.tsx
@@ -18,7 +18,7 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { colors, radius } from "../../design/tokens";
+import { colors, fonts, radius, textStyles } from "../../design/tokens";
 import { MemoraNative } from "../../native/MemoraNative";
 import type { SummaryOptionsDTO } from "../../native/MemoraNative.types";
 import type { AudioFile } from "../../types/memora";
@@ -775,13 +775,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 18,
     paddingVertical: 10,
   },
-  backgroundButtonText: { color: colors.text, fontSize: 13, fontWeight: "600" },
+  backgroundButtonText: { color: colors.text, ...textStyles.footnoteBold },
   confirmActions: { flexDirection: "row", gap: 8, marginTop: 16 },
   confirmBody: {
     color: colors.textTertiary,
-    fontSize: 12.5,
-    lineHeight: 18,
     textAlign: "center",
+    ...textStyles.caption,
   },
   confirmCancel: {
     alignItems: "center",
@@ -791,7 +790,7 @@ const styles = StyleSheet.create({
     height: 44,
     justifyContent: "center",
   },
-  confirmCancelText: { color: colors.text, fontSize: 14, fontWeight: "600" },
+  confirmCancelText: { color: colors.text, ...textStyles.footnoteBold },
   confirmCard: {
     backgroundColor: "#FFFFFF",
     borderRadius: radius.lg,
@@ -806,7 +805,7 @@ const styles = StyleSheet.create({
     height: 44,
     justifyContent: "center",
   },
-  confirmDeleteText: { color: "#FFFFFF", fontSize: 14, fontWeight: "600" },
+  confirmDeleteText: { color: colors.surface, ...textStyles.footnoteBold },
   confirmOverlay: {
     alignItems: "center",
     backgroundColor: "rgba(0,0,0,0.5)",
@@ -819,10 +818,9 @@ const styles = StyleSheet.create({
   },
   confirmTitle: {
     color: colors.text,
-    fontSize: 16,
-    fontWeight: "700",
     marginBottom: 6,
     textAlign: "center",
+    ...textStyles.callout,
   },
   generateBack: {
     alignItems: "center",
@@ -838,8 +836,7 @@ const styles = StyleSheet.create({
   },
   generateButtonText: {
     color: colors.surface,
-    fontSize: 16,
-    fontWeight: "600",
+    ...textStyles.callout,
   },
   generateCenter: {
     alignItems: "center",
@@ -855,12 +852,11 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   generateChipActive: { backgroundColor: colors.text },
-  generateChipText: { color: colors.text, fontSize: 12.5, fontWeight: "600" },
+  generateChipText: { color: colors.text, ...textStyles.captionBold },
   generateDesc: {
     color: colors.textTertiary,
-    fontSize: 13,
-    lineHeight: 22,
     textAlign: "center",
+    ...textStyles.footnote,
   },
   generateHandle: {
     alignSelf: "center",
@@ -895,19 +891,17 @@ const styles = StyleSheet.create({
   generateModeCardActive: { backgroundColor: colors.text },
   generateModeDesc: {
     color: colors.textTertiary,
-    fontSize: 11,
-    lineHeight: 15,
     marginTop: 2,
+    ...textStyles.caption,
   },
   generateModeRow: { flexDirection: "row", gap: 8, marginBottom: 14 },
   generateModeTextActive: { color: colors.surface },
   generateModeTitle: {
     color: colors.text,
-    fontSize: 13.5,
-    fontWeight: "600",
     marginBottom: 2,
+    ...textStyles.footnoteBold,
   },
-  generateModelLabel: { color: colors.text, fontSize: 14.5, fontWeight: "500" },
+  generateModelLabel: { color: colors.text, ...textStyles.footnoteBold },
   generateModelRow: {
     alignItems: "center",
     flexDirection: "row",
@@ -916,7 +910,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 2,
     paddingTop: 6,
   },
-  generateModelValue: { color: colors.textTertiary, fontSize: 14 },
+  generateModelValue: { color: colors.textTertiary, ...textStyles.footnote },
   generateModelValueWrap: {
     alignItems: "center",
     flexDirection: "row",
@@ -924,11 +918,10 @@ const styles = StyleSheet.create({
   },
   generateName: {
     color: colors.text,
-    fontSize: 21,
-    fontWeight: "700",
     paddingBottom: 18,
     paddingHorizontal: 18,
     paddingTop: 2,
+    ...textStyles.sectionTitle,
   },
   generatePanel: {
     borderTopColor: "#F2F2F2",
@@ -946,8 +939,7 @@ const styles = StyleSheet.create({
   },
   generateSkipText: {
     color: colors.textTertiary,
-    fontSize: 13,
-    fontWeight: "600",
+    ...textStyles.footnoteBold,
   },
   generateTemplateRow: {
     flexDirection: "row",
@@ -957,10 +949,9 @@ const styles = StyleSheet.create({
   },
   generateTitle: {
     color: colors.text,
-    fontSize: 19,
-    fontWeight: "700",
     marginBottom: 8,
     textAlign: "center",
+    ...textStyles.sectionTitle,
   },
   generationContent: {
     alignItems: "center",
@@ -970,18 +961,16 @@ const styles = StyleSheet.create({
   },
   generationDescription: {
     color: colors.textTertiary,
-    fontSize: 12.5,
-    lineHeight: 18,
     marginBottom: 20,
     maxWidth: 260,
     textAlign: "center",
+    ...textStyles.caption,
   },
   generationLabel: {
     color: colors.text,
-    fontSize: 17,
-    fontWeight: "700",
     marginBottom: 22,
     marginTop: 22,
+    ...textStyles.callout,
   },
   generationScreen: { backgroundColor: "#FFFFFF", flex: 1 },
   highlightButton: {
@@ -995,9 +984,7 @@ const styles = StyleSheet.create({
   highlightCount: {
     backgroundColor: colors.text,
     borderRadius: 8,
-    color: "#FFFFFF",
-    fontSize: 9,
-    fontWeight: "700",
+    color: colors.surface,
     minWidth: 16,
     overflow: "hidden",
     paddingHorizontal: 3,
@@ -1005,6 +992,7 @@ const styles = StyleSheet.create({
     right: -2,
     textAlign: "center",
     top: -2,
+    ...textStyles.captionBold,
   },
   island: {
     alignItems: "center",
@@ -1029,10 +1017,9 @@ const styles = StyleSheet.create({
   islandDotPaused: { backgroundColor: colors.textTertiary },
   islandGeneration: { gap: 8, height: 36, paddingHorizontal: 14, width: 198 },
   islandGenerationText: {
-    color: "#FFFFFF",
+    color: colors.surface,
     flex: 1,
-    fontSize: 12,
-    fontWeight: "500",
+    ...textStyles.caption,
   },
   islandRecording: { gap: 8, height: 36, paddingHorizontal: 14, width: 156 },
   islandSnackbar: {
@@ -1043,16 +1030,14 @@ const styles = StyleSheet.create({
     width: 304,
   },
   islandSnackbarText: {
-    color: "#FFFFFF",
+    color: colors.surface,
     flex: 1,
-    fontSize: 13,
-    fontWeight: "500",
+    ...textStyles.footnote,
   },
   islandTimer: {
-    color: "#FFFFFF",
-    fontFamily: "Menlo",
+    color: colors.surface,
     fontSize: 12,
-    fontWeight: "500",
+    ...fonts.mono.regular,
   },
   islandWave: { backgroundColor: "#FFFFFF", borderRadius: 1, width: 2 },
   islandWaveform: {
@@ -1092,17 +1077,15 @@ const styles = StyleSheet.create({
   },
   recordingStatus: {
     color: colors.textTertiary,
-    fontSize: 14,
-    fontWeight: "500",
     marginBottom: 8,
+    ...textStyles.footnote,
   },
   recordingTime: {
     color: colors.text,
-    fontFamily: "Menlo",
     fontSize: 44,
-    fontWeight: "600",
     letterSpacing: -0.44,
     marginBottom: 36,
+    ...fonts.mono.regular,
   },
   roundIcon: {
     alignItems: "center",
@@ -1111,7 +1094,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   skipButton: { alignItems: "center", paddingBottom: 20 },
-  skipButtonText: { color: colors.textTertiary, fontSize: 13, fontWeight: "500" },
+  skipButtonText: { color: colors.textTertiary, ...textStyles.footnote },
   stopButton: {
     alignItems: "center",
     backgroundColor: colors.text,
@@ -1133,7 +1116,7 @@ const styles = StyleSheet.create({
     minHeight: 96,
     paddingTop: 14,
   },
-  transcriptText: { color: colors.textTertiary, fontSize: 13.5, lineHeight: 24 },
+  transcriptText: { color: colors.textTertiary, ...textStyles.footnote },
   wave: { borderRadius: 2, width: 4 },
   waveform: {
     alignItems: "flex-end",

--- a/apps/mobile-expo/src/screens/AskAIScreen.tsx
+++ b/apps/mobile-expo/src/screens/AskAIScreen.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Alert, Keyboard, LayoutAnimation, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { Screen } from '../components/Screen';
 import { EmptyState, LoadingState } from '../components/StateViews';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 import { askMessages } from '../mocks/memoraData';
 import { MemoraNative } from '../native/MemoraNative';
 import type { KnowledgeQueryScope } from '../native/MemoraNative.types';
@@ -232,15 +232,14 @@ const styles = StyleSheet.create({
   },
   scopeText: {
     color: colors.textSecondary,
-    fontSize: 13,
-    fontWeight: '600',
     textAlign: 'center',
+    ...textStyles.footnoteBold,
   },
   scopeTextActive: {
     borderRadius: radius.pill,
     color: colors.text,
   },
-  scopeCaption: { color: colors.textTertiary, fontSize: 11.5, lineHeight: 17, marginTop: -8 },
+  scopeCaption: { color: colors.textTertiary, marginTop: -8, ...textStyles.caption },
   newChatButton: { alignItems: 'center', height: 44, justifyContent: 'center', marginRight: -spacing.sm, width: 44 },
   iconPressed: { opacity: 0.45 },
   thread: {
@@ -258,8 +257,7 @@ const styles = StyleSheet.create({
   },
   userText: {
     color: colors.text,
-    fontSize: 14.5,
-    lineHeight: 21,
+    ...textStyles.body,
   },
   assistantBlock: {
     borderBottomColor: colors.borderLight,
@@ -268,21 +266,20 @@ const styles = StyleSheet.create({
     paddingBottom: spacing.sm,
   },
   messageActions: { alignItems: 'center', flexDirection: 'row', gap: spacing.md, marginTop: 2 },
-  messageActionText: { color: colors.textTertiary, fontSize: 11, fontWeight: '500' },
-  messageTime: { color: colors.border, fontSize: 10.5, marginLeft: 'auto' },
+  messageActionText: { color: colors.textTertiary, ...textStyles.caption },
+  messageTime: { color: colors.border, marginLeft: 'auto', ...textStyles.caption },
   emptyAsk: { gap: spacing.xs, paddingTop: spacing.xl },
-  emptyTitle: { color: colors.text, fontSize: 18, fontWeight: '700' },
-  emptySubtitle: { color: colors.textTertiary, fontSize: 12, fontWeight: '600', letterSpacing: 0.2, paddingBottom: spacing.sm },
+  emptyTitle: { color: colors.text, ...textStyles.callout },
+  emptySubtitle: { color: colors.textTertiary, paddingBottom: spacing.sm, ...textStyles.captionBold },
   suggestions: { borderTopColor: colors.borderLight, borderTopWidth: 1 },
   suggestion: { alignItems: 'center', borderBottomColor: colors.borderLight, borderBottomWidth: 1, flexDirection: 'row', minHeight: 52, paddingHorizontal: 2 },
   suggestionPressed: { opacity: 0.46 },
-  suggestionText: { color: colors.text, flex: 1, fontSize: 14, lineHeight: 20 },
+  suggestionText: { color: colors.text, flex: 1, ...textStyles.body },
   typingDots: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs, paddingVertical: spacing.sm },
   typingDot: { backgroundColor: colors.border, borderRadius: 3, height: 6, width: 6 },
   assistantText: {
     color: colors.text,
-    fontSize: 15,
-    lineHeight: 25,
+    ...textStyles.body,
   },
   sources: {
     flexDirection: 'row',
@@ -297,8 +294,7 @@ const styles = StyleSheet.create({
   },
   sourceText: {
     color: colors.textTertiary,
-    fontSize: 10.5,
-    fontWeight: '500',
+    ...textStyles.caption,
   },
   askBox: {
     alignItems: 'center',
@@ -325,11 +321,9 @@ const styles = StyleSheet.create({
   askInput: {
     color: colors.text,
     flex: 1,
-    fontSize: 15,
-    fontWeight: '400',
-    lineHeight: 21,
     maxHeight: 96,
     minHeight: 24,
+    ...textStyles.body,
   },
   sendButton: {
     alignItems: 'center',

--- a/apps/mobile-expo/src/screens/AuthFlowScreen.tsx
+++ b/apps/mobile-expo/src/screens/AuthFlowScreen.tsx
@@ -12,7 +12,7 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { colors, radius } from "../design/tokens";
+import { colors, fonts, radius, textStyles } from "../design/tokens";
 
 type Stage = "onboarding" | "login" | "email" | "code" | "paywall";
 const slides = [
@@ -419,7 +419,7 @@ const styles = StyleSheet.create({
   flex: { flex: 1 },
   page: { flex: 1, paddingBottom: 36, paddingHorizontal: 28, paddingTop: 20 },
   skipRow: { alignItems: "flex-end" },
-  skip: { color: colors.textTertiary, fontSize: 13, fontWeight: "500" },
+  skip: { color: colors.textTertiary, ...textStyles.footnoteBold },
   onboardingCenter: {
     alignItems: "center",
     flex: 1,
@@ -429,15 +429,13 @@ const styles = StyleSheet.create({
   onboardingCopy: { gap: 8, paddingHorizontal: 18 },
   authTitle: {
     color: colors.text,
-    fontSize: 22,
-    fontWeight: "700",
     textAlign: "center",
+    ...textStyles.title2,
   },
   authBody: {
     color: colors.textTertiary,
-    fontSize: 14,
-    lineHeight: 24,
     textAlign: "center",
+    ...textStyles.body,
   },
   recordGlyph: {
     alignItems: "center",
@@ -462,9 +460,8 @@ const styles = StyleSheet.create({
   },
   glyphTitle: {
     color: colors.text,
-    fontSize: 13,
-    fontWeight: "700",
     marginBottom: 1,
+    ...textStyles.footnoteBold,
   },
   glyphLineLong: {
     backgroundColor: colors.border,
@@ -495,7 +492,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 18,
     width: 220,
   },
-  askGlyphText: { color: colors.textTertiary, flex: 1, fontSize: 13 },
+  askGlyphText: { color: colors.textTertiary, flex: 1, ...textStyles.footnote },
   askGlyphCircle: {
     backgroundColor: "rgba(255,255,255,0.12)",
     borderRadius: 15,
@@ -520,7 +517,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   primaryDisabled: { backgroundColor: colors.border },
-  primaryText: { color: colors.surface, fontSize: 16, fontWeight: "600" },
+  primaryText: { color: colors.surface, ...textStyles.callout },
   loginHero: {
     alignItems: "center",
     flex: 1,
@@ -529,9 +526,7 @@ const styles = StyleSheet.create({
   },
   appTitle: {
     color: colors.text,
-    fontSize: 34,
-    fontWeight: "700",
-    letterSpacing: -0.68,
+    ...textStyles.display,
   },
   loginActions: { gap: 10 },
   googleButton: {
@@ -544,8 +539,8 @@ const styles = StyleSheet.create({
     height: 52,
     justifyContent: "center",
   },
-  googleG: { color: "#4285F4", fontSize: 18, fontWeight: "700" },
-  googleText: { color: colors.text, fontSize: 15, fontWeight: "600" },
+  googleG: { color: "#4285F4", ...textStyles.callout },
+  googleText: { color: colors.text, ...textStyles.bodyBold },
   emailButton: {
     alignItems: "center",
     backgroundColor: colors.surfaceAlt,
@@ -553,13 +548,12 @@ const styles = StyleSheet.create({
     height: 52,
     justifyContent: "center",
   },
-  emailText: { color: colors.text, fontSize: 15, fontWeight: "600" },
+  emailText: { color: colors.text, ...textStyles.bodyBold },
   terms: {
     color: colors.textTertiary,
-    fontSize: 11,
-    lineHeight: 16,
     marginTop: 16,
     textAlign: "center",
+    ...textStyles.caption,
   },
   back: {
     alignItems: "center",
@@ -573,16 +567,15 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     borderWidth: 1,
     color: colors.text,
-    fontSize: 16,
     paddingHorizontal: 16,
     paddingVertical: 14,
+    ...textStyles.callout,
   },
   codeHint: {
     color: colors.textTertiary,
-    fontSize: 13,
-    lineHeight: 20,
     marginTop: 6,
     textAlign: "center",
+    ...textStyles.footnote,
   },
   codeBoxes: { flexDirection: "row", gap: 8 },
   codeBox: {
@@ -596,27 +589,25 @@ const styles = StyleSheet.create({
   },
   codeDigit: {
     color: colors.text,
-    fontFamily: "Menlo",
     fontSize: 18,
-    fontWeight: "600",
+    ...fonts.mono.regular,
   },
   codeInput: {
     borderColor: colors.border,
     borderRadius: 12,
     borderWidth: 1,
     color: colors.text,
-    fontFamily: "Menlo",
     fontSize: 15,
     paddingHorizontal: 14,
     paddingVertical: 12,
+    ...fonts.mono.regular,
   },
   paywallContent: { flex: 1, paddingHorizontal: 6, paddingTop: 6 },
   paywallHero: { alignItems: "center", gap: 4, marginBottom: 22 },
   proTitle: {
     color: colors.text,
-    fontSize: 26,
-    fontWeight: "700",
     letterSpacing: -0.26,
+    ...textStyles.title2,
   },
   features: { gap: 12, marginBottom: 22 },
   feature: { alignItems: "center", flexDirection: "row", gap: 10 },
@@ -628,7 +619,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     width: 18,
   },
-  featureText: { color: colors.text, flex: 1, fontSize: 13.5 },
+  featureText: { color: colors.text, flex: 1, ...textStyles.footnote },
   plans: { flexDirection: "row", gap: 10 },
   plan: {
     borderColor: colors.border,
@@ -643,28 +634,26 @@ const styles = StyleSheet.create({
     backgroundColor: colors.text,
     borderRadius: 6,
     color: colors.surface,
-    fontSize: 9.5,
-    fontWeight: "700",
     left: 10,
     paddingHorizontal: 7,
     paddingVertical: 2,
     position: "absolute",
     top: -10,
+    ...textStyles.captionBold,
   },
   planLabel: {
     color: colors.text,
-    fontSize: 13,
-    fontWeight: "600",
     marginBottom: 4,
+    ...textStyles.footnoteBold,
   },
-  planPrice: { color: colors.text, fontSize: 17, fontWeight: "700" },
-  planNote: { color: colors.textTertiary, fontSize: 11, marginTop: 2 },
+  planPrice: { color: colors.text, ...textStyles.callout },
+  planNote: { color: colors.textTertiary, marginTop: 2, ...textStyles.caption },
   cancelHint: {
     color: colors.textTertiary,
-    fontSize: 11.5,
     marginBottom: 16,
     marginTop: 8,
     textAlign: "center",
+    ...textStyles.caption,
   },
-  legal: { color: colors.textTertiary, fontSize: 11, textAlign: "center" },
+  legal: { color: colors.textTertiary, textAlign: "center", ...textStyles.caption },
 });

--- a/apps/mobile-expo/src/screens/FileDetailScreen.tsx
+++ b/apps/mobile-expo/src/screens/FileDetailScreen.tsx
@@ -14,7 +14,7 @@ import { EmptyState, ErrorState, LoadingState } from '../components/StateViews';
 import { StatusPill } from '../components/StatusPill';
 import { formatRecordedAt } from '../utils/formatRecordedAt';
 import { TranscriptionProgressCard } from '../components/TranscriptionProgressCard';
-import { colors, radius, shadow, spacing } from '../design/tokens';
+import { colors, radius, shadow, spacing, textStyles } from '../design/tokens';
 import { useAudioFile } from '../features/files/useAudioFiles';
 import { useMemoNotes } from '../features/memo/useMemoNotes';
 import { usePlayback } from '../features/playback/usePlayback';
@@ -630,27 +630,27 @@ function activeTranscriptSegmentIdForPosition(
 
 const styles = StyleSheet.create({
   summaryTab: { gap: spacing.lg, paddingBottom: spacing.lg, paddingTop: spacing.sm },
-  summaryMeta: { color: colors.textTertiary, fontSize: 12.5 },
+  summaryMeta: { color: colors.textTertiary, ...textStyles.caption },
   summarySection: { gap: spacing.sm },
-  summarySectionTitle: { color: colors.text, fontSize: 15, fontWeight: '700' },
+  summarySectionTitle: { color: colors.text, ...textStyles.bodyBold },
   chapterRow: { alignItems: 'center', flexDirection: 'row', gap: spacing.md, paddingHorizontal: spacing.xs, paddingVertical: spacing.sm },
-  chapterTime: { color: colors.textTertiary, fontFamily: 'Menlo', fontSize: 12, width: 38 },
-  chapterText: { color: colors.text, flex: 1, fontSize: 14 },
-  decisionText: { color: colors.textSecondary, fontSize: 14, lineHeight: 24 },
+  chapterTime: { color: colors.textTertiary, width: 38, ...textStyles.monoBody },
+  chapterText: { color: colors.text, flex: 1, ...textStyles.body },
+  decisionText: { color: colors.textSecondary, ...textStyles.body },
   actionList: { gap: spacing.md },
   actionItem: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm },
-  actionItemText: { color: colors.text, flex: 1, fontSize: 14, lineHeight: 20 },
+  actionItemText: { color: colors.text, flex: 1, ...textStyles.body },
   taskifyButton: { alignItems: 'center', flexDirection: 'row', gap: 2, minHeight: 36, paddingHorizontal: spacing.xs },
-  taskifyText: { color: colors.textTertiary, fontSize: 11.5, fontWeight: '600' },
+  taskifyText: { color: colors.textTertiary, ...textStyles.captionBold },
   attachmentHeading: { alignItems: 'baseline', flexDirection: 'row', gap: spacing.sm },
-  attachmentCaption: { color: colors.textTertiary, fontSize: 11 },
+  attachmentCaption: { color: colors.textTertiary, ...textStyles.caption },
   attachmentGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
   attachmentThumbWrap: { aspectRatio: 1, borderRadius: radius.md, overflow: 'hidden', width: '30.8%' },
   attachmentThumb: { height: '100%', width: '100%' },
   attachmentLocalBadge: { backgroundColor: 'rgba(13,13,13,0.7)', borderRadius: 6, left: 5, paddingHorizontal: 5, paddingVertical: 2, position: 'absolute', top: 5 },
-  attachmentLocalBadgeText: { color: colors.surface, fontSize: 8.5, fontWeight: '600' },
+  attachmentLocalBadgeText: { color: colors.surface, ...textStyles.captionBold },
   attachmentAdd: { alignItems: 'center', aspectRatio: 1, borderColor: colors.border, borderRadius: radius.md, borderStyle: 'dashed', borderWidth: 1.5, justifyContent: 'center', width: '30.8%' },
-  attachmentStorageNote: { color: colors.textTertiary, fontSize: 12, fontWeight: '500', marginTop: 2 },
+  attachmentStorageNote: { color: colors.textTertiary, marginTop: 2, ...textStyles.caption },
   detailTopRow: { alignItems: 'center', flexDirection: 'row', justifyContent: 'space-between', marginHorizontal: -6 },
   headerActions: {
     alignItems: 'center',
@@ -677,7 +677,7 @@ const styles = StyleSheet.create({
   sourceMeta: {
     color: colors.textTertiary,
     flex: 1,
-    fontSize: 12,
+    ...textStyles.caption,
   },
   summaryIntro: {
     gap: spacing.lg,
@@ -750,18 +750,15 @@ const styles = StyleSheet.create({
   },
   renameError: {
     color: colors.danger,
-    fontSize: 13,
-    fontWeight: '800',
+    ...textStyles.footnoteBold,
   },
   summaryError: {
     color: colors.danger,
-    fontSize: 13,
-    fontWeight: '800',
+    ...textStyles.footnoteBold,
   },
   summaryMetadata: {
     color: colors.textTertiary,
-    fontSize: 12,
-    fontWeight: '800',
+    ...textStyles.caption,
   },
   heroSummary: {
     color: colors.text,
@@ -798,7 +795,7 @@ const styles = StyleSheet.create({
   },
   summaryButtonText: {
     color: colors.surface,
-    fontWeight: '900',
+    ...textStyles.bodyBold,
   },
   ghostButton: {
     alignItems: 'center',
@@ -814,9 +811,9 @@ const styles = StyleSheet.create({
     fontWeight: '900',
   },
   detailHeader: { flex: 1, gap: spacing.xs },
-  detailTitle: { color: colors.text, fontSize: 24, fontWeight: '700', letterSpacing: -0.24 },
+  detailTitle: { color: colors.text, letterSpacing: -0.24, ...textStyles.title2 },
   detailMetaRow: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm },
-  detailMeta: { color: colors.textTertiary, fontSize: 12.5 },
+  detailMeta: { color: colors.textTertiary, ...textStyles.caption },
   tabs: {
     borderBottomColor: colors.border,
     borderBottomWidth: 1,
@@ -835,8 +832,7 @@ const styles = StyleSheet.create({
   },
   tabText: {
     color: colors.textTertiary,
-    fontSize: 14,
-    fontWeight: '600',
+    ...textStyles.footnoteBold,
   },
   tabTextActive: {
     color: colors.text,
@@ -870,7 +866,7 @@ const styles = StyleSheet.create({
   },
   askSuggestionText: {
     color: colors.text,
-    fontSize: 14,
+    ...textStyles.body,
   },
   askInputRow: {
     alignItems: 'center',
@@ -884,30 +880,29 @@ const styles = StyleSheet.create({
   },
   askInputPlaceholder: {
     color: colors.textInverse,
-    fontSize: 14,
+    ...textStyles.body,
   },
   sheetBackdrop: { backgroundColor: 'rgba(0,0,0,0.32)', flex: 1, justifyContent: 'flex-end' },
   sheetPress: { width: '100%' },
   sheet: { gap: spacing.xs, paddingBottom: spacing.md, paddingHorizontal: spacing.md, paddingTop: spacing.sm },
   sheetFallback: { backgroundColor: colors.surface },
   sheetRow: { alignItems: 'center', backgroundColor: 'rgba(255,255,255,0.86)', borderRadius: radius.md, flexDirection: 'row', gap: spacing.sm, minHeight: 50, paddingHorizontal: spacing.md },
-  sheetRowText: { color: colors.text, fontSize: 15, fontWeight: '500' },
-  deleteText: { color: colors.danger, fontSize: 15, fontWeight: '500' },
+  sheetRowText: { color: colors.text, ...textStyles.bodyBold },
+  deleteText: { color: colors.danger, ...textStyles.bodyBold },
   renameBackdrop: { alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.32)', flex: 1, justifyContent: 'center', padding: spacing.lg },
   renameSheet: { borderRadius: radius.lg, gap: spacing.md, overflow: 'hidden', padding: spacing.lg, width: '100%' },
-  renameSheetTitle: { color: colors.text, fontSize: 16, fontWeight: '700' },
-  renameSheetInput: { backgroundColor: colors.surfaceAlt, borderColor: colors.border, borderRadius: radius.md, borderWidth: 1, color: colors.text, fontSize: 15, minHeight: 46, paddingHorizontal: spacing.md },
+  renameSheetTitle: { color: colors.text, ...textStyles.callout },
+  renameSheetInput: { backgroundColor: colors.surfaceAlt, borderColor: colors.border, borderRadius: radius.md, borderWidth: 1, color: colors.text, minHeight: 46, paddingHorizontal: spacing.md, ...textStyles.body },
   renameSheetActions: { flexDirection: 'row', gap: spacing.sm, justifyContent: 'flex-end' },
   renameCancel: { paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
-  renameCancelText: { color: colors.textTertiary, fontSize: 14, fontWeight: '600' },
+  renameCancelText: { color: colors.textTertiary, ...textStyles.footnoteBold },
   renameSave: { backgroundColor: colors.text, borderRadius: radius.md, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
-  renameSaveText: { color: colors.surface, fontSize: 14, fontWeight: '600' },
-  deleteDescription: { color: colors.textSecondary, fontSize: 12.5, lineHeight: 19, textAlign: 'center' }, deleteConfirm: { backgroundColor: colors.danger, borderRadius: radius.md, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
-  exportTitle: { color: colors.text, fontSize: 16, fontWeight: '700', marginBottom: spacing.sm, marginLeft: spacing.xs }, exportRow: { alignItems: 'center', backgroundColor: 'rgba(255,255,255,0.86)', borderRadius: radius.md, flexDirection: 'row', gap: spacing.sm, minHeight: 52, paddingHorizontal: spacing.md }, exportIcon: { alignItems: 'center', borderRadius: 6, height: 24, justifyContent: 'center', width: 24 }, exportRowLabel: { color: colors.text, flex: 1, fontSize: 14.5, fontWeight: '500' }, exportRowStatus: { color: colors.textTertiary, fontSize: 11.5 },
+  renameSaveText: { color: colors.surface, ...textStyles.footnoteBold },
+  deleteDescription: { color: colors.textSecondary, textAlign: 'center', ...textStyles.footnote }, deleteConfirm: { backgroundColor: colors.danger, borderRadius: radius.md, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
+  exportTitle: { color: colors.text, marginBottom: spacing.sm, marginLeft: spacing.xs, ...textStyles.callout }, exportRow: { alignItems: 'center', backgroundColor: 'rgba(255,255,255,0.86)', borderRadius: radius.md, flexDirection: 'row', gap: spacing.sm, minHeight: 52, paddingHorizontal: spacing.md }, exportIcon: { alignItems: 'center', borderRadius: 6, height: 24, justifyContent: 'center', width: 24 }, exportRowLabel: { color: colors.text, flex: 1, ...textStyles.body }, exportRowStatus: { color: colors.textTertiary, ...textStyles.caption },
   bodyText: {
     color: colors.text,
-    fontSize: 14,
-    lineHeight: 24,
+    ...textStyles.body,
   },
   todoList: {
     gap: spacing.md,
@@ -920,8 +915,7 @@ const styles = StyleSheet.create({
   todoText: {
     color: colors.text,
     flex: 1,
-    fontSize: 15,
-    fontWeight: '700',
+    ...textStyles.bodyBold,
   },
   segment: {
     borderRadius: 10,
@@ -937,14 +931,11 @@ const styles = StyleSheet.create({
   },
   speaker: {
     color: colors.textSecondary,
-    fontSize: 12,
-    fontWeight: '600',
+    ...textStyles.captionBold,
   },
   time: {
     color: colors.textTertiary,
-    fontFamily: 'Menlo',
-    fontSize: 10.5,
-    fontWeight: '500',
+    ...textStyles.monoBody,
   },
   transcriptScroll: {
     flexShrink: 1,
@@ -954,10 +945,10 @@ const styles = StyleSheet.create({
     paddingBottom: spacing.md,
   },
   transcriptEmpty: { alignItems: 'center', gap: spacing.sm, paddingHorizontal: spacing.lg, paddingTop: spacing.xl },
-  transcriptEmptyTitle: { color: colors.text, fontSize: 15, fontWeight: '700' },
-  transcriptEmptyBody: { color: colors.textTertiary, fontSize: 12.5, lineHeight: 20, textAlign: 'center' },
+  transcriptEmptyTitle: { color: colors.text, ...textStyles.bodyBold },
+  transcriptEmptyBody: { color: colors.textTertiary, textAlign: 'center', ...textStyles.footnote },
   startTranscription: { backgroundColor: colors.text, borderRadius: radius.md, marginTop: spacing.xs, paddingHorizontal: spacing.lg, paddingVertical: spacing.sm },
-  startTranscriptionText: { color: colors.surface, fontSize: 13.5, fontWeight: '600' },
+  startTranscriptionText: { color: colors.surface, ...textStyles.footnoteBold },
   memoEditBlock: {
     gap: spacing.sm,
   },
@@ -967,11 +958,10 @@ const styles = StyleSheet.create({
     borderRadius: radius.lg,
     borderWidth: 1,
     color: colors.text,
-    fontSize: 14,
-    lineHeight: 25,
     minHeight: 120,
     padding: spacing.md,
     textAlignVertical: 'top',
+    ...textStyles.body,
   },
   memoSaveButton: {
     alignItems: 'center',
@@ -983,8 +973,7 @@ const styles = StyleSheet.create({
   },
   memoSaveText: {
     color: colors.surface,
-    fontSize: 13.5,
-    fontWeight: '600',
+    ...textStyles.footnoteBold,
   },
   memoDisplayBlock: {
     backgroundColor: '#FAFAFA',
@@ -993,13 +982,11 @@ const styles = StyleSheet.create({
   },
   memoDisplayText: {
     color: colors.text,
-    fontSize: 14,
-    lineHeight: 25,
+    ...textStyles.body,
   },
   memoPlaceholderText: {
     color: colors.border,
-    fontSize: 14,
-    lineHeight: 25,
+    ...textStyles.body,
   },
   photoRow: {
     flexDirection: 'row',

--- a/apps/mobile-expo/src/screens/HomeScreen.tsx
+++ b/apps/mobile-expo/src/screens/HomeScreen.tsx
@@ -23,7 +23,7 @@ import { Screen } from '../components/Screen';
 import { FloatingBottomSheet } from '../components/FloatingBottomSheet';
 import { SheetCard } from '../components/SheetCard';
 import { EmptyState, ErrorState } from '../components/StateViews';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 import { useCaptureFlow } from '../features/capture/CaptureFlowProvider';
 import { useAudioFiles } from '../features/files/useAudioFiles';
 import { MemoraNative } from '../native/MemoraNative';
@@ -239,7 +239,7 @@ function ProjectsGrid({ projects, files, onSelect }: { projects: string[]; files
             onPress={() => onSelect(project)}
             style={({ pressed }) => [homeStyles.projectCard, pressed && homeStyles.cardPressed]}
           >
-            <View style={[homeStyles.projectAvatar, { backgroundColor: ['#1A7F6B', '#5F6368', '#9AA0A6', '#3C4043'][i % 4] }]}>
+            <View style={[homeStyles.projectAvatar, { backgroundColor: [colors.categorySlate, colors.categoryTeal, colors.categoryOlive, colors.categoryMauve][i % 4] }]}>
               <Text style={homeStyles.projectAvatarText}>{project.slice(0, 1)}</Text>
             </View>
             <View>
@@ -354,43 +354,43 @@ function groupByDate(files: AudioFile[]) {
 
 // ── styles ───────────────────────────────────────────────
 const homeStyles = StyleSheet.create({
-  screenTitle: { color: colors.text, fontSize: 30, fontWeight: '700', letterSpacing: -0.4 },
+  screenTitle: { color: colors.text, ...textStyles.screenTitle },
   headerActions: { flexDirection: 'row' },
   headerBtn: { alignItems: 'center', height: 44, justifyContent: 'center', width: 44 },
   pressed: { opacity: 0.62, transform: [{ scale: 0.93 }] },
   emptyActions: { gap: spacing.sm },
   importEmptyAction: { alignItems: 'center', borderColor: colors.accent, borderRadius: radius.md, borderWidth: 1, flexDirection: 'row', gap: spacing.xs, justifyContent: 'center', marginTop: -spacing.xs, minHeight: 44, paddingHorizontal: spacing.lg },
-  importEmptyActionText: { color: colors.accent, fontSize: 14, fontWeight: '600' },
+  importEmptyActionText: { color: colors.accent, ...textStyles.footnoteBold },
 
   // projects
   projectsGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
   projectCard: { borderColor: colors.borderLight, borderRadius: radius.md, borderWidth: 1, gap: 28, padding: spacing.md, width: '48%' },
   cardPressed: { opacity: 0.76, transform: [{ scale: 0.97 }] },
   projectAvatar: { alignItems: 'center', borderRadius: radius.sm, height: 26, justifyContent: 'center', width: 26 },
-  projectAvatarText: { color: colors.surface, fontSize: 12, fontWeight: '700' },
-  projectName: { color: colors.text, fontSize: 14, fontWeight: '600' },
-  projectCount: { color: colors.textTertiary, fontSize: 12, marginTop: 2 },
+  projectAvatarText: { color: colors.surface, ...textStyles.captionBold },
+  projectName: { color: colors.text, ...textStyles.footnoteBold },
+  projectCount: { color: colors.textTertiary, marginTop: 2, ...textStyles.caption },
   projectView: { gap: spacing.xs },
   projectHeader: { alignItems: 'center', flexDirection: 'row', gap: spacing.sm, marginBottom: spacing.sm },
-  projectViewTitle: { color: colors.text, fontSize: 17, fontWeight: '700' },
+  projectViewTitle: { color: colors.text, ...textStyles.callout },
   backBtn: { alignItems: 'center', height: 44, justifyContent: 'center', marginLeft: -spacing.sm, width: 44 },
 
   // sheets
   sheet: { gap: spacing.xs, paddingBottom: spacing.md, paddingHorizontal: spacing.md, paddingTop: spacing.sm },
   sheetRow: { alignItems: 'center', backgroundColor: 'rgba(255,255,255,0.86)', borderRadius: radius.md, flexDirection: 'row', gap: spacing.sm, minHeight: 50, paddingHorizontal: spacing.md },
-  sheetRowText: { color: colors.text, flex: 1, fontSize: 15, fontWeight: '500' },
-  sheetDeleteText: { color: colors.danger, flex: 1, fontSize: 15, fontWeight: '500' },
+  sheetRowText: { color: colors.text, flex: 1, ...textStyles.bodyBold },
+  sheetDeleteText: { color: colors.danger, flex: 1, ...textStyles.bodyBold },
   sheetRowPressed: { opacity: 0.72, transform: [{ scale: 0.985 }] },
 
   // modal
   modalBackdrop: { alignItems: 'center', backgroundColor: colors.overlay, flex: 1, justifyContent: 'center', padding: spacing.lg },
   modalCard: { backgroundColor: colors.surface, borderRadius: radius.lg, gap: spacing.sm, padding: spacing.lg, width: '100%' },
-  modalTitle: { color: colors.text, fontSize: 16, fontWeight: '700', textAlign: 'center' },
-  modalBody: { color: colors.textSecondary, fontSize: 13, lineHeight: 19, textAlign: 'center' },
+  modalTitle: { color: colors.text, textAlign: 'center', ...textStyles.callout },
+  modalBody: { color: colors.textSecondary, textAlign: 'center', ...textStyles.footnote },
   modalActions: { flexDirection: 'row', gap: spacing.sm, marginTop: spacing.sm },
   modalCancel: { alignItems: 'center', backgroundColor: colors.surfaceAlt, borderRadius: radius.md, flex: 1, paddingVertical: spacing.md },
   modalDelete: { alignItems: 'center', backgroundColor: colors.danger, borderRadius: radius.md, flex: 1, paddingVertical: spacing.md },
-  modalCancelText: { color: colors.text, fontSize: 14, fontWeight: '600' },
-  modalDeleteText: { color: colors.surface, fontSize: 14, fontWeight: '600' },
+  modalCancelText: { color: colors.text, ...textStyles.footnoteBold },
+  modalDeleteText: { color: colors.surface, ...textStyles.footnoteBold },
   disabled: { opacity: 0.58 },
 });

--- a/apps/mobile-expo/src/screens/SettingsScreen.tsx
+++ b/apps/mobile-expo/src/screens/SettingsScreen.tsx
@@ -4,7 +4,7 @@ import { AppIcon as Ionicons } from '../components/AppIcon';
 import { useRouter } from 'expo-router';
 import { Screen } from '../components/Screen';
 import { Section } from '../components/Section';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 import { MemoraNative } from '../native/MemoraNative';
 import type { BridgeInfoDTO, CustomVocabularyDTO, SettingsDTO, SummaryOptionsDTO } from '../native/MemoraNative.types';
 import type { SettingsGroup } from '../types/memora';
@@ -664,8 +664,7 @@ const styles = StyleSheet.create({
   },
   v6GroupTitle: {
     color: colors.textTertiary,
-    fontSize: 13,
-    fontWeight: '600',
+    ...textStyles.footnoteBold,
   },
   v6Card: {
     backgroundColor: colors.canvas,
@@ -676,7 +675,7 @@ const styles = StyleSheet.create({
   },
   developerToggle: { alignItems: 'center', alignSelf: 'center', flexDirection: 'row', gap: spacing.xs, marginTop: spacing.sm, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
   developerTogglePressed: { opacity: 0.65, transform: [{ scale: 0.96 }] },
-  developerToggleText: { color: colors.textTertiary, fontSize: 12, fontWeight: '500' },
+  developerToggleText: { color: colors.textTertiary, ...textStyles.caption },
   v6Row: {
     alignItems: 'center',
     flexDirection: 'row',
@@ -687,7 +686,7 @@ const styles = StyleSheet.create({
   v6RowTitle: {
     color: colors.text,
     flexShrink: 0,
-    fontSize: 15,
+    ...textStyles.body,
   },
   v6RowTitleDestructive: {
     color: colors.danger,
@@ -696,8 +695,8 @@ const styles = StyleSheet.create({
   v6RowValue: {
     color: colors.textTertiary,
     flex: 1,
-    fontSize: 13,
     textAlign: 'right',
+    ...textStyles.footnote,
   },
   v6Badge: {
     borderRadius: 8,
@@ -706,8 +705,7 @@ const styles = StyleSheet.create({
   },
   v6BadgeText: {
     color: colors.surface,
-    fontSize: 11,
-    fontWeight: '700',
+    ...textStyles.captionBold,
   },
   toggleRow: {
     alignItems: 'center',
@@ -732,7 +730,7 @@ const styles = StyleSheet.create({
   },
   vocabularyReplacement: {
     color: colors.textSecondary,
-    fontSize: 13,
+    ...textStyles.footnote,
   },
   vocabularyAddButton: {
     alignItems: 'center',
@@ -742,8 +740,7 @@ const styles = StyleSheet.create({
   },
   vocabularyAddText: {
     color: colors.accent,
-    fontSize: 15,
-    fontWeight: '600',
+    ...textStyles.bodyBold,
   },
   modalBackdrop: {
     alignItems: 'center',
@@ -761,8 +758,7 @@ const styles = StyleSheet.create({
   },
   modalTitle: {
     color: colors.text,
-    fontSize: 20,
-    fontWeight: '700',
+    ...textStyles.sectionTitle,
   },
   modalInput: {
     borderColor: colors.border,
@@ -789,7 +785,7 @@ const styles = StyleSheet.create({
   },
   modalButtonText: {
     color: colors.textSecondary,
-    fontSize: 15,
+    ...textStyles.body,
   },
   modalSaveButton: {
     backgroundColor: colors.accent,
@@ -797,8 +793,7 @@ const styles = StyleSheet.create({
   },
   modalSaveText: {
     color: colors.textInverse,
-    fontSize: 15,
-    fontWeight: '600',
+    ...textStyles.bodyBold,
   },
   modalDeleteButton: {
     alignItems: 'center',
@@ -808,7 +803,7 @@ const styles = StyleSheet.create({
   },
   modalDeleteText: {
     color: colors.danger,
-    fontSize: 15,
+    ...textStyles.body,
   },
   groupCard: {
     backgroundColor: colors.surface,
@@ -817,8 +812,7 @@ const styles = StyleSheet.create({
   },
   description: {
     color: colors.textSecondary,
-    fontSize: 14,
-    lineHeight: 21,
+    ...textStyles.footnote,
   },
   rows: {
     gap: spacing.md,
@@ -852,8 +846,7 @@ const styles = StyleSheet.create({
   },
   segmentText: {
     color: colors.textSecondary,
-    fontSize: 13,
-    fontWeight: '500',
+    ...textStyles.footnoteBold,
   },
   segmentTextSelected: {
     color: colors.surface,
@@ -876,14 +869,12 @@ const styles = StyleSheet.create({
   },
   label: {
     color: colors.text,
-    fontSize: 15,
-    fontWeight: '500',
+    ...textStyles.bodyBold,
   },
   value: {
     color: colors.textSecondary,
-    fontSize: 13,
-    fontWeight: '400',
     marginTop: 4,
+    ...textStyles.footnote,
   },
   dot: {
     borderRadius: radius.pill,

--- a/apps/mobile-expo/src/screens/TasksScreen.tsx
+++ b/apps/mobile-expo/src/screens/TasksScreen.tsx
@@ -6,7 +6,7 @@ import { FloatingBottomSheet } from '../components/FloatingBottomSheet';
 import { Screen } from '../components/Screen';
 import { SheetCard } from '../components/SheetCard';
 import { EmptyState } from '../components/StateViews';
-import { colors, radius, spacing } from '../design/tokens';
+import { colors, radius, spacing, textStyles } from '../design/tokens';
 
 type DueChoice = '今日' | '明日' | '日付を選択';
 
@@ -176,29 +176,29 @@ const styles = StyleSheet.create({
   doneButton: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs },
   doneGroup: { gap: spacing.sm },
   group: { gap: spacing.sm },
-  groupLabel: { fontSize: 12, fontWeight: '600' },
-  input: { backgroundColor: 'rgba(255,255,255,0.86)', borderRadius: radius.md, color: colors.text, fontSize: 15, paddingHorizontal: spacing.md, paddingVertical: spacing.md },
+  groupLabel: { ...textStyles.captionBold },
+  input: { backgroundColor: 'rgba(255,255,255,0.86)', borderRadius: radius.md, color: colors.text, paddingHorizontal: spacing.md, paddingVertical: spacing.md, ...textStyles.body },
   pressed: { opacity: 0.78, transform: [{ scale: 0.98 }] },
   saveButton: { alignItems: 'center', backgroundColor: colors.text, borderRadius: radius.lg, flexDirection: 'row', gap: spacing.xs, justifyContent: 'center', marginTop: spacing.lg, paddingVertical: spacing.md },
-  saveButtonText: { color: '#FFFFFF', fontSize: 16, fontWeight: '600' },
+  saveButtonText: { color: '#FFFFFF', ...textStyles.callout },
   sheet: { minHeight: 340, padding: spacing.lg },
-  sheetTitle: { color: colors.text, fontSize: 18, fontWeight: '700', marginBottom: spacing.md },
-  fieldLabel: { color: colors.textSecondary, fontSize: 12, fontWeight: '600', marginBottom: spacing.xs, marginTop: spacing.md },
+  sheetTitle: { color: colors.text, marginBottom: spacing.md, ...textStyles.callout },
+  fieldLabel: { color: colors.textSecondary, marginBottom: spacing.xs, marginTop: spacing.md, ...textStyles.captionBold },
   dueRow: { flexDirection: 'row', gap: spacing.sm },
   dueChip: { backgroundColor: colors.surfaceAlt, borderRadius: radius.pill, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
   dueChipActive: { backgroundColor: colors.text },
-  dueChipText: { color: colors.textSecondary, fontSize: 13, fontWeight: '600' },
+  dueChipText: { color: colors.textSecondary, ...textStyles.footnoteBold },
   dueChipTextActive: { color: '#FFFFFF' },
   projectRow: { backgroundColor: colors.surfaceAlt, borderRadius: radius.md, paddingHorizontal: spacing.md, paddingVertical: spacing.md },
-  projectText: { color: colors.text, fontSize: 14.5 },
+  projectText: { color: colors.text, ...textStyles.body },
   metaRow: { alignItems: 'center', flexDirection: 'row', gap: 6, marginTop: 3 },
   metaDot: { backgroundColor: colors.textTertiary, borderRadius: 1.5, height: 3, width: 3 },
   sourceShrink: { flexShrink: 1 },
-  sourceLink: { color: colors.textTertiary, fontSize: 12, textDecorationLine: 'underline' },
-  sourceText: { color: colors.textTertiary, fontSize: 12 },
-  dueBadge: { fontSize: 11.5, fontWeight: '600' },
+  sourceLink: { color: colors.textTertiary, textDecorationLine: 'underline', ...textStyles.caption },
+  sourceText: { color: colors.textTertiary, ...textStyles.caption },
+  dueBadge: { ...textStyles.captionBold },
   taskBody: { flex: 1 },
   taskRow: { borderBottomColor: colors.borderLight, borderBottomWidth: 1, flexDirection: 'row', gap: spacing.md, paddingVertical: 14 },
-  taskTitle: { color: colors.text, fontSize: 14.5, fontWeight: '500', lineHeight: 20 },
+  taskTitle: { color: colors.text, ...textStyles.body },
   taskTitleCompleted: { color: colors.textTertiary, textDecorationLine: 'line-through' },
 });


### PR DESCRIPTION
## Summary
- `apps/mobile-expo/src/design/tokens.ts` を単一ソース化（色をFigmaのモノトーンに更新、フォントをIBM Plex Sans JPに、textStyles 12種をFigmaのタイプスケールと1:1定義）
- `app/_layout.tsx` で IBM Plex Sans JP を本番ロード（従来は未ロードでシステムフォント表示だった）
- 全画面・共有コンポーネントの `fontSize`/`fontWeight` 直書きを `textStyles.*` プリセット経由に統一（Home / Tasks / Ask AI / Settings / File Detail / Auth flow / Capture flow / 共有コンポーネント一式）

## Base branch について
このPRは `feat/custom-vocabulary`（#146）の上に積んだスタックPRです。#146 マージ後に base が `main` へ自動的に retarget されます。

## Test plan
- [x] `npm run typecheck` pass
- [x] `npx expo export --platform web` pass
- [x] ブラウザ実描画で Home / File Detail（概要・文字起こしタブ）/ Auth Paywall / Settings を確認し、Figmaとタイプスケールが一致することを確認
- [ ] iOS Simulator実機での目視確認は未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)