### PR TITLE
docs: Notion/ChatGPT書き出しの1.0契約確定（export契約・設定連携行の文言更新）

### DIFF
--- a/apps/mobile-expo/src/screens/FileDetailScreen.tsx
+++ b/apps/mobile-expo/src/screens/FileDetailScreen.tsx
@@ -297,9 +297,9 @@ export function FileDetailScreen({ fileId }: { fileId?: string }) {
     pendingExportActionRef.current = null;
 
     if (action === 'notion') {
-      Alert.alert('Notion に転記', '連携の接続後に有効になります。');
+      Alert.alert('Notion に転記', '1.0対象（実装準備中）です。実装は別PRで進めます。');
     } else if (action === 'chatgpt') {
-      Alert.alert('ChatGPT に共有', '連携の接続後に有効になります。');
+      Alert.alert('ChatGPT に共有', '1.0対象（実装準備中）です。実装は別PRで進めます。');
     } else if (action === 'share') {
       void handleShare();
     }
@@ -712,13 +712,13 @@ export function FileDetailScreen({ fileId }: { fileId?: string }) {
           <Button variant="ghost" background={null} onPress={() => closeExportThen('notion')} style={styles.sheetAction}>
             <Ionicons color={colors.text} name="document-outline" size={18} />
             <View style={styles.sheetActionCopy}><Button.Label>Notion に転記</Button.Label></View>
-            <Text style={styles.exportRowStatus}>未接続</Text>
+            <Text style={styles.exportRowStatus}>1.0対象（準備中）</Text>
           </Button>
           <Separator />
           <Button variant="ghost" background={null} onPress={() => closeExportThen('chatgpt')} style={styles.sheetAction}>
             <Ionicons color={colors.text} name="chatbubble-outline" size={18} />
             <View style={styles.sheetActionCopy}><Button.Label>ChatGPT に共有</Button.Label></View>
-            <Text style={styles.exportRowStatus}>未接続</Text>
+            <Text style={styles.exportRowStatus}>1.0対象（準備中）</Text>
           </Button>
           <Separator />
           <Button variant="ghost" background={null} onPress={() => closeExportThen('share')} style={styles.sheetAction}>

--- a/apps/mobile-expo/src/screens/SettingsScreen.tsx
+++ b/apps/mobile-expo/src/screens/SettingsScreen.tsx
@@ -77,6 +77,7 @@ export function SettingsScreen() {
   }, [settings.summaryProvider]);
 
   const notConnected = () => Alert.alert('準備中', NOT_CONNECTED_MESSAGE);
+  const exportNotReady = (label: string) => Alert.alert(label, '1.0対象（実装準備中）です。実装は別PRで進めます。');
 
   return (
     <Screen title="設定">
@@ -117,8 +118,8 @@ export function SettingsScreen() {
       </SettingsGroupCard>
 
       <SettingsGroupCard title="連携">
-        <SettingsRow onPress={notConnected} title="Notion に書き出す" value="未接続" />
-        <SettingsRow onPress={notConnected} title="ChatGPT に共有" value="未接続" />
+        <SettingsRow onPress={() => exportNotReady('Notion に書き出す')} title="Notion に書き出す" value="1.0対象（準備中）" />
+        <SettingsRow onPress={() => exportNotReady('ChatGPT に共有')} title="ChatGPT に共有" value="1.0対象（準備中）" />
       </SettingsGroupCard>
 
       <SettingsGroupCard title="言語">

--- a/docs/rn-export-contract-2026-08-10.md
+++ b/docs/rn-export-contract-2026-08-10.md
@@ -1,0 +1,115 @@
+# RN Export（Notion / ChatGPT）契約
+
+- 日付: 2026-08-10
+- 決定: オーナー決定（ユーザー）
+- 種別: 1.0 スコープ確定・契約（実装は別 PR）
+
+## 1. 決定
+
+- **Notion / ChatGPT への書き出し（export）を 1.0 の対象とする**（2026-08-10、オーナー決定）。
+- 本ドキュメントは「対象・方式・DTO・bridge・設定 UI の置き場所」を確定する **契約** であり、
+  OAuth / API 呼び出し等の**実連携は別 PR で実装**する（本 PR では実装しない）。
+- 画面の「未接続」表示は「1.0 対象（実装準備中）」へ更新済み（文言のみ）。
+
+## 2. 対象データ
+
+現在 Share sheet で書き出している内容（`FileDetailScreen.handleShare`）を引き継ぐ。
+
+| 項目 | 内容 | 出所 |
+|---|---|---|
+| title | 録音タイトル | `file.title` |
+| summary | 要約（Markdown） | `file.summary`（`generateSummary` bridge） |
+| transcript | 文字起こし（`time text` の行並び） | `file.transcript`（STT bridge / shared SwiftData `Transcript`） |
+| action items | 対応（タスク化導線から生成。実装は後続 PR で確定） | Tasks（`TodoItem`）連携を検討 |
+
+> 将来的なスコープ: 添付（写真等）、プロジェクト情報。1.0 では対象外のため契約に含めない。
+
+## 3. 契約（DTO / bridge）
+
+### 3.1 `ExportDestination`
+
+```ts
+export type ExportDestination = 'notion' | 'chatgpt' | 'file';
+```
+
+- `file`: 現行 Share sheet の「Markdown / TXT / SRT で書き出す」相当（既存 `handleShare`）。
+- `notion` / `chatgpt`: 本契約で 1.0 対象。実装は別 PR。
+
+### 3.2 `ExportPayloadDTO`
+
+```ts
+export type ExportPayloadDTO = {
+  title: string;
+  text: string;            // summary + transcript を結合した Markdown テキスト
+  createdAt?: string;      // ISO 8601
+  sourceFileId: string;    // 共有 SwiftData の AudioFile id
+  destination: ExportDestination;
+  // 実装 PR で確定する拡張候補:
+  // format?: 'markdown' | 'txt' | 'srt';
+  // transcriptOnly?: boolean;
+  // summaryOnly?: boolean;
+};
+```
+
+### 3.3 bridge 関数（提案）
+
+```ts
+// ネイティブ側で実際の転記処理を行う（トークン管理・API 呼び出しは native のみで扱う方針）
+export async function exportToDestination(payload: ExportPayloadDTO): Promise<ExportResultDTO>;
+```
+
+```ts
+export type ExportResultDTO = {
+  ok: boolean;
+  destination: ExportDestination;
+  refId?: string;      // Notion page id 等。未確定
+  error?: string;      // 人間可読のエラー理由
+};
+```
+
+- 実装時の命名は既存 bridge（`MemoraNative`）の命名規則に合わせて確定する。
+- **認証情報・API キーは RN 側に置かず、native（Keychain）側のみで扱う**（CLAUDE.md の Keychain 方針・ADR-004 に準拠）。
+
+## 4. 認証方式（要検討・実装時確定）
+
+| Destination | 方式候補 | 状態 |
+|---|---|---|
+| Notion | Integration token（`ntn_...`）／ OAuth（AppStore 審査・UX 面） | **要検討**（1.0 でどちらにするかは実装 PR で確定） |
+| ChatGPT | 共有テキスト（ショートカット経由のクリップボード / URL scheme / App Intents） | **要検討**（1.0 でどの導線を使うかは実装 PR で確定） |
+| file | 現行 Share sheet のまま | 実装済み（変更なし） |
+
+### 未確定事項（実装時に決定し、本契約を更新する）
+
+- Notion: Integration token か OAuth か。scope（page 書き込み先の選択 UI）。
+- ChatGPT: 共有の具体的な導線（API 契約は公開されていないため、OS 標準の共有/クリップボード経由を前提に検討）。
+- API キー / トークンの保存先とローテーション方針（Keychain 前提）。
+- エラー・リトライ・レート制限の扱い。
+- 書き出し履歴（成功可否）をアプリ側に残すか。
+
+## 5. 設定 UI（置き場所）
+
+- **Settings の「連携」グループ**（`SettingsScreen.tsx`）:
+  - 「Notion に書き出す」「ChatGPT に共有」の 2 行を 1.0 対象として**有効化**する方針。
+    - 未接続時: 「1.0 対象（準備中）」表示（本 PR で文言更新済み）。
+    - 実装後: 接続状態・認証導線（OAuth / token 入力）・ON/OFF をこの行で扱う。
+- **FileDetail の書き出し行**（`FileDetailScreen.tsx`）:
+  - 「書き出す」シートの「Notion に転記」「ChatGPT に共有」の接続先をここに配置。
+    - 未接続時: 「1.0 対象（準備中）」表示（本 PR で文言更新済み）。
+    - 実装後: 接続済みなら実際の転記を実行、未接続なら設定画面への導線を提示。
+- 連携行の接続状態は settings store（UserDefaults）に持ち、トークン等は native のみで保持する。
+
+## 6. 実装ステップ（別 PR で進める）
+
+1. 契約確定の受け入れ（本 PR）: parity matrix・release readiness の更新、画面文言の更新。
+2. bridge 契約の実装（Lane G）: `exportToDestination` + `ExportPayloadDTO` / `ExportResultDTO` を
+   `MemoraNative` に追加し、型を確定。
+3. Notion 連携（Lane G / C）: Integration token または OAuth の決定 → native 実装 → Settings「連携」の有効化。
+4. ChatGPT 連携（Lane G / C）: 共有導線の決定 → native 実装 → Settings「連携」の有効化。
+5. FileDetail 書き出し行の接続（Lane F）: 「Notion に転記」「ChatGPT に共有」の実導線。
+6. 実機 QA（Lane E）: 実接続での書き出し・エラー・再認証フローの確認。
+
+### この PR でやらないこと
+
+- 実 API 連携・OAuth・ネットワーク実装
+- 認証情報の取り扱い（Keychain 登録等）
+- export の実データ作成

--- a/docs/rn-full-cutover-execution-plan.md
+++ b/docs/rn-full-cutover-execution-plan.md
@@ -101,7 +101,7 @@ RN への完全移行が「完了」と言えるのは、以下の全てが観�
 | STT | 実装 | SpeechAnalyzer on RN host（#152 / #160）+ 共有 SwiftData `Transcript` へ persist + `onTranscriptionEvent`。RN transcript タブは実データ表示（2026-08-10 監査） | 実機 QA（音声認識権限・精度） | B / G → F | 実録音の文字起こしが RN transcript タブに表示 |
 | 要約 summary | 実装 | `generateSummary` bridge + `MemoraSharedStoreSummaryGenerator` を host 接続済み（2026-08-10 監査）。API キーは Keychain | 実機 QA（API キー実接続） | C / G | 実ファイルの要約が RN File Detail に出る |
 | 検索 search | 実装 | Ask AI UI + `queryKnowledge` bridge + `MemoraSharedStoreKnowledgeQuery`（host 接続済み、2026-08-10 監査） | retrieval 品質・モデル選択。1.0 必須/推奨の判定 | C / G | Ask で実検索結果が返る |
-| 書き出し export | 実装 | Share sheet で title+summary+transcript を書き出し（実装済み） | Notion / ChatGPT 契約（未定・要ユーザー決定） | G / F | 実ファイルの書き出しが成立 |
+| 書き出し export | 実装 | Share sheet で title+summary+transcript を書き出し（実装済み） | Notion / ChatGPT は **1.0 対象に決定（2026-08-10）**。契約は `docs/rn-export-contract-2026-08-10.md`、実装は別 PR | G / F | 実ファイルの書き出しが成立 |
 | 設定 / Keychain | 実装 | UserDefaults settings store + RN 設定 UI、ホスト側 Keychain（service `com.memora.app`、ADR-004 実装済み）。連携行（Notion / ChatGPT / PLAUD / Omi 等）は未接続 Alert | 連携行のスコープ判断 | C / G | 設定永続化、API キーは native 側のみ |
 | プロジェクト move | 実装 | `moveAudioFile` bridge + Home のプロジェクト表示（`file.project`） | UI wiring（FileDetail / Tasks シートは未接続 Alert） | G / F | プロジェクト移動が永続化 |
 | タスク tasks | 実装 | **#180 で実データ化済み**: `TodoItem` SwiftData + `MemoraSharedStoreTaskBridgeAdapter` + TasksScreen CRUD | 日付選択・タスク化導線（FileDetail / AskAI）の配線 | C / F | タスクの実データ契約 |

--- a/docs/rn-release-readiness-2026-08-10.md
+++ b/docs/rn-release-readiness-2026-08-10.md
@@ -127,11 +127,11 @@
 | STT | **実装済み** | `MemoraRNTranscriptionHandler` → `STTService`（`SpeechAnalyzerService26` / `SFSpeechRecognizer`）。shared SwiftData `Transcript` へ persist、`onTranscriptionEvent` を emit | 必須 | §8 保護対象、実機 QA（音声認識権限） |
 | 要約 summary | **実装済み** | `MemoraSharedStoreSummaryGenerator`（bootstrap で接続）＋ `generateSummary` ＋ API キー（Keychain / Local は不要） | 必須 | API キー設定（実装済み）、provider 選択、実機 QA |
 | 検索 search（Ask AI） | **実装済み** | `MemoraSharedStoreKnowledgeQuery`（bootstrap で接続）＋ `queryKnowledge` ＋ `LocalRetrievalEngine`。AskAIScreen は実 bridge を呼ぶ | 推奨 | retrieval 索引・モデル選択。1.0 必須か要判断 |
-| 書き出し export | **一部** | Share sheet で title+summary+transcript を共有（FileDetail `handleShare`）。Notion / ChatGPT 行は「未接続」Alert | 推奨 | Notion / ChatGPT 契約（未定・要ユーザー決定） |
+| 書き出し export | **一部** | Share sheet で title+summary+transcript を共有（FileDetail `handleShare`）。Notion / ChatGPT 行は「1.0対象（準備中）」表示（2026-08-10 文言更新） | **必須** | 契約は `docs/rn-export-contract-2026-08-10.md`（1.0 対象に決定 2026-08-10）、実装は別 PR |
 | Tasks | **実装済み（#180）** | `TodoItem` + `MemoraSharedStoreTaskBridgeAdapter` + TasksScreen CRUD。残: 日付選択 / タスク化導線 | 必須 | タスク化導線（FileDetail・AskAI）の配線 |
 | プロジェクト move | **一部** | HomeScreen のプロジェクトセグメント表示（`file.project`）+ `moveAudioFile` bridge。FileDetail「プロジェクトに移動」と Tasks シートのプロジェクトは未接続（Alert / 固定「個人タスク」） | 推奨 | move UI wiring（Lane F / G） |
 | 設定（基盤） | **実装済み** | settings store（UserDefaults: summaryProvider / transcriptionMode / speechAnalyzerEnabled）、customVocabulary（SwiftData）、API キー（Keychain） | 必須 | なし |
-| 設定（連携・未接続行） | **未接続** | Notion / ChatGPT 連携、PLAUD / Omi デバイス管理、プッシュ通知（Switch はローカル state のみ）、キャッシュ消去 / 全データ書き出し、ログアウト / アカウント削除、表示言語 / 文字起こし言語、要約テンプレート（固定「議事録」）— すべて `notConnected` Alert | スコープ判断 | 各バックエンド / 契約の決定 |
+| 設定（連携・未接続行） | **未接続** | Notion / ChatGPT 連携は「1.0対象（準備中）」（2026-08-10 決定・実装は別 PR）。PLAUD / Omi デバイス管理、プッシュ通知（Switch はローカル state のみ）、キャッシュ消去 / 全データ書き出し、ログアウト / アカウント削除、表示言語 / 文字起こし言語、要約テンプレート（固定「議事録」）— Notion / ChatGPT 以外は `notConnected` Alert | スコープ判断 | Notion / ChatGPT 以外は各バックエンド / 契約の決定 |
 | 通知 / Widget / Broadcast Extension | **未接続（RN 同梱なし）** | `MemoraWidget/`・`MemoraBroadcastExtension/` はソース保持のみ。RN xcodeproj に target なし。Info.plist に `UIBackgroundModes` なし。Live Activity は SwiftUI 依存のため削除により消滅 | ソース保持は必須 / 同梱はスコープ判断 | 同梱可否・ライブ配信方針の決定 |
 | STT transcript 表示 | **実装済み** | FileDetail の文字起こしタブは `file.transcript`（bridge 実データ）を表示。cleanedText 切替、`TranscriptionProgressCard` + `useTranscriptionTask` で実 STT 開始、segment tap で seek+play | 必須 | 実機 QA |
 | 認証 / ペイウォール | **未接続（UI のみ・dev-gated）** | `AuthFlowScreen` は onboarding/login/email/code/paywall フローを実装するが、外部認証・コード送信・購入は「準備中」Alert。`releaseGate.ts` の `DEV_ONLY_ROUTES`（auth / preview / dev-fonts）で release ビルドから到達不能 | スコープ判断（要決定） | 認証バックエンド・IAP の契約 |
@@ -158,7 +158,7 @@
 
 - **1.0 で「バックグラウンド録音」を主張するか**（`UIBackgroundModes: audio` の要否。SwiftUI 側は主張を除去して追加しない方針だったため、RN で方針を再確認）。
 - **認証方式とペイウォールの有無**: Apple / Google / メール OTP のどれか、IAP（RevenueCat 等）を使うか。
-- **Notion / ChatGPT 連携の 1.0 対象可否**（export 契約）。
+- ~~Notion / ChatGPT 連携の 1.0 対象可否~~（export 契約）→ **2026-08-10 に 1.0 対象で決定**（契約: `docs/rn-export-contract-2026-08-10.md`、実装は別 PR）。
 - **Widget / Broadcast Extension の RN 同梱**を 1.0 で行うか（Live Activity は SwiftUI 依存で消滅したため、動的アイランド方針の再決定を含む）。
 - **検索（Ask AI）の 1.0 必須 / 推奨**の判定。
 - **root `MemoraTests/`（孤立）は 2026-08-10 に削除済み**。


### PR DESCRIPTION
## 目的
- Notion / ChatGPT への書き出し（export）を **1.0 の対象とする**ことを確定（2026-08-10、オーナー決定）。
- 本PRは「契約（対象・方式・DTO・bridge・設定UIの置き場所）」の確定と画面文言の更新のみ。**実API連携（OAuth・API呼び出し）は実装しない**（別PR）。

## 変更内容
- 新規 `docs/rn-export-contract-2026-08-10.md`: export契約（`ExportDestination` / `ExportPayloadDTO` / `exportToDestination` bridgeの提案、Notion Integration token or OAuth・ChatGPT共有テキストの未確定事項、設定UIの置き場所、実装ステップを列挙）
- `docs/rn-full-cutover-execution-plan.md`: parity matrix「書き出し export」行を「1.0対象に決定（2026-08-10）」に更新
- `docs/rn-release-readiness-2026-08-10.md`: export行を必須化、設定（連携）行・要ユーザー決定事項を更新
- `apps/mobile-expo/src/screens/SettingsScreen.tsx`: 連携行（Notion に書き出す / ChatGPT に共有）の「未接続」→「1.0対象（準備中）」（文言のみ）
- `apps/mobile-expo/src/screens/FileDetailScreen.tsx`: 書き出し行の「未接続」→「1.0対象（準備中）」＋Alert文言更新（文言のみ）

## 検証
- `npm ci`（lock変更なし）→ pass
- `npm run typecheck` → pass
- `npm test` → 19 tests pass
- `CI=1 npx expo export --platform web` → pass
- `git diff --check` → pass
- 変更は docs/** と SettingsScreen.tsx / FileDetailScreen.tsx（文言のみ）

## 対象外（別PR）
- 実API連携・OAuth・ネットワーク実装
- 認証情報・APIキーの取り扱い